### PR TITLE
feat(mobile): implement claim success screen and sender dashboard

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -19,6 +19,15 @@ export default function RootLayout() {
           options={{ animation: "slide_from_right" }}
         />
         <Stack.Screen
+          name="claim/success"
+          options={{ animation: "slide_from_right" }}
+        />
+        <Stack.Screen name="send/index" options={{ animation: "fade" }} />
+        <Stack.Screen
+          name="send/create"
+          options={{ animation: "slide_from_right" }}
+        />
+        <Stack.Screen
           name="security/index"
           options={{ animation: "slide_from_right" }}
         />

--- a/mobile/app/claim/index.tsx
+++ b/mobile/app/claim/index.tsx
@@ -9,6 +9,7 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
+import { useRouter } from "expo-router";
 import * as Clipboard from "expo-clipboard";
 import { lookupClaimByToken, ClaimLookupResult } from "../src/claims/service";
 import {
@@ -25,7 +26,17 @@ const summarizeToken = (token: string): string => {
   return `${token.slice(0, 18)}...${token.slice(-12)}`;
 };
 
+const createMockTxHash = (seed: string): string => {
+  const hex = Array.from(seed)
+    .map((char) => char.charCodeAt(0).toString(16).padStart(2, "0"))
+    .join("")
+    .slice(0, 64);
+
+  return (hex + "0".repeat(64)).slice(0, 64);
+};
+
 export default function ClaimTokenEntryScreen() {
+  const router = useRouter();
   const [tokenInput, setTokenInput] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -135,6 +146,27 @@ export default function ClaimTokenEntryScreen() {
             <Text selectable style={styles.tokenPreview}>
               {summarizeToken(normalizedToken)}
             </Text>
+
+            <TouchableOpacity
+              style={styles.claimButton}
+              onPress={() => {
+                const txHash = createMockTxHash(
+                  `${result.accountId}:${normalizedToken}`,
+                );
+
+                router.push({
+                  pathname: "/claim/success",
+                  params: {
+                    amount: result.amount,
+                    asset: result.asset,
+                    accountId: result.accountId,
+                    txHash,
+                  },
+                });
+              }}
+            >
+              <Text style={styles.claimButtonText}>Complete Claim</Text>
+            </TouchableOpacity>
           </View>
         )}
       </ScrollView>
@@ -243,5 +275,17 @@ const styles = StyleSheet.create({
   tokenPreview: {
     color: "#E2E8F0",
     fontFamily: "Courier",
+  },
+  claimButton: {
+    marginTop: 12,
+    borderRadius: 10,
+    backgroundColor: "#16A34A",
+    paddingVertical: 12,
+    alignItems: "center",
+  },
+  claimButtonText: {
+    color: "#FFFFFF",
+    fontWeight: "700",
+    fontSize: 14,
   },
 });

--- a/mobile/app/claim/success.tsx
+++ b/mobile/app/claim/success.tsx
@@ -1,0 +1,253 @@
+import React, { useEffect, useRef } from 'react';
+import {
+  Alert,
+  Animated,
+  Linking,
+  SafeAreaView,
+  ScrollView,
+  Share,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+
+const readParam = (value: string | string[] | undefined, fallback = ''): string => {
+  if (Array.isArray(value)) {
+    return value[0] ?? fallback;
+  }
+
+  return value ?? fallback;
+};
+
+const summarizeMiddle = (value: string): string => {
+  if (value.length <= 24) {
+    return value;
+  }
+
+  return `${value.slice(0, 12)}...${value.slice(-10)}`;
+};
+
+export default function ClaimSuccessScreen() {
+  const router = useRouter();
+  const { amount, asset, accountId, txHash } = useLocalSearchParams();
+
+  const parsedAmount = readParam(amount, '0');
+  const parsedAsset = readParam(asset, 'XLM:native');
+  const parsedAccountId = readParam(accountId, 'unknown-account');
+  const parsedTxHash = readParam(txHash, '');
+
+  const pulse = useRef(new Animated.Value(1)).current;
+
+  useEffect(() => {
+    const animation = Animated.loop(
+      Animated.sequence([
+        Animated.timing(pulse, {
+          toValue: 1.08,
+          duration: 600,
+          useNativeDriver: true,
+        }),
+        Animated.timing(pulse, {
+          toValue: 1,
+          duration: 600,
+          useNativeDriver: true,
+        }),
+      ]),
+    );
+
+    animation.start();
+
+    return () => {
+      animation.stop();
+    };
+  }, [pulse]);
+
+  const explorerUrl = parsedTxHash
+    ? `https://stellar.expert/explorer/public/tx/${parsedTxHash}`
+    : '';
+
+  const handleOpenExplorer = async () => {
+    if (!explorerUrl) {
+      return;
+    }
+
+    const canOpen = await Linking.canOpenURL(explorerUrl);
+    if (!canOpen) {
+      Alert.alert('Unable to open explorer link right now.');
+      return;
+    }
+
+    await Linking.openURL(explorerUrl);
+  };
+
+  const handleShare = async () => {
+    const message = [
+      'Claim completed on Bridgelet.',
+      `Amount: ${parsedAmount} ${parsedAsset}`,
+      `Account: ${parsedAccountId}`,
+      parsedTxHash ? `Transaction: ${parsedTxHash}` : '',
+      explorerUrl,
+    ]
+      .filter(Boolean)
+      .join('\n');
+
+    await Share.share({ message });
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView contentContainerStyle={styles.content}>
+        <Animated.View style={[styles.iconWrap, { transform: [{ scale: pulse }] }]}> 
+          <Text style={styles.icon}>✓</Text>
+        </Animated.View>
+
+        <Text style={styles.title}>Claim Successful</Text>
+        <Text style={styles.subtitle}>
+          Your transfer has been claimed and recorded successfully.
+        </Text>
+
+        <View style={styles.summaryCard}>
+          <Text style={styles.cardTitle}>Transaction Summary</Text>
+          <View style={styles.summaryRow}>
+            <Text style={styles.label}>Amount</Text>
+            <Text style={styles.value}>{parsedAmount}</Text>
+          </View>
+          <View style={styles.summaryRow}>
+            <Text style={styles.label}>Asset</Text>
+            <Text style={styles.value}>{parsedAsset}</Text>
+          </View>
+          <View style={styles.summaryRow}>
+            <Text style={styles.label}>Account</Text>
+            <Text style={styles.value}>{summarizeMiddle(parsedAccountId)}</Text>
+          </View>
+          <View style={styles.summaryRow}>
+            <Text style={styles.label}>Tx Hash</Text>
+            <Text style={styles.value}>{summarizeMiddle(parsedTxHash || 'pending')}</Text>
+          </View>
+        </View>
+
+        <TouchableOpacity
+          style={[styles.secondaryButton, !explorerUrl && styles.disabledButton]}
+          onPress={handleOpenExplorer}
+          disabled={!explorerUrl}
+        >
+          <Text style={styles.secondaryText}>Open in Stellar Explorer</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity style={styles.secondaryButton} onPress={handleShare}>
+          <Text style={styles.secondaryText}>Share Receipt</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={styles.primaryButton}
+          onPress={() => router.replace('/send')}
+        >
+          <Text style={styles.primaryText}>Done</Text>
+        </TouchableOpacity>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#0F172A',
+  },
+  content: {
+    padding: 20,
+    alignItems: 'stretch',
+    gap: 12,
+  },
+  iconWrap: {
+    width: 88,
+    height: 88,
+    borderRadius: 44,
+    alignSelf: 'center',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#166534',
+    borderWidth: 1,
+    borderColor: '#22C55E',
+    marginTop: 8,
+  },
+  icon: {
+    color: '#DCFCE7',
+    fontSize: 42,
+    fontWeight: '700',
+    lineHeight: 44,
+  },
+  title: {
+    textAlign: 'center',
+    color: '#FFFFFF',
+    fontSize: 28,
+    fontWeight: '700',
+    marginTop: 8,
+  },
+  subtitle: {
+    textAlign: 'center',
+    color: '#94A3B8',
+    fontSize: 15,
+    lineHeight: 22,
+    marginBottom: 4,
+  },
+  summaryCard: {
+    marginTop: 8,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#334155',
+    backgroundColor: '#111827',
+    padding: 14,
+    gap: 10,
+  },
+  cardTitle: {
+    color: '#E2E8F0',
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  summaryRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  label: {
+    color: '#94A3B8',
+    fontSize: 14,
+  },
+  value: {
+    color: '#F8FAFC',
+    fontSize: 14,
+    fontWeight: '600',
+    maxWidth: '65%',
+    textAlign: 'right',
+  },
+  primaryButton: {
+    marginTop: 8,
+    borderRadius: 12,
+    backgroundColor: '#2563EB',
+    paddingVertical: 14,
+    alignItems: 'center',
+  },
+  primaryText: {
+    color: '#FFFFFF',
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  secondaryButton: {
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#334155',
+    backgroundColor: '#0B1220',
+    paddingVertical: 14,
+    alignItems: 'center',
+  },
+  secondaryText: {
+    color: '#E2E8F0',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  disabledButton: {
+    opacity: 0.45,
+  },
+});

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -2,11 +2,9 @@ import React, { useEffect, useState } from 'react';
 import { View, StyleSheet, ActivityIndicator } from 'react-native';
 import { Redirect } from 'expo-router';
 import { secureStorage } from './src/utils/storage';
-import { SenderFlow } from './src/sender/SenderFlow';
 
 export default function HomeIndex() {
   const [hasOnboarded, setHasOnboarded] = useState<boolean | null>(null);
-  const router = useRouter();
 
   useEffect(() => {
     const checkOnboardingStatus = async () => {
@@ -28,11 +26,7 @@ export default function HomeIndex() {
     return <Redirect href="/(onboarding)" />;
   }
 
-  return (
-    <View style={styles.container}>
-      <SenderFlow />
-    </View>
-  );
+  return <Redirect href="/send" />;
 }
 
 const styles = StyleSheet.create({

--- a/mobile/app/send/create.tsx
+++ b/mobile/app/send/create.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { SafeAreaView, StyleSheet } from 'react-native';
+import { SenderFlow } from '../src/sender/SenderFlow';
+
+export default function CreateTransferScreen() {
+  return (
+    <SafeAreaView style={styles.container}>
+      <SenderFlow />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#0F172A',
+  },
+});

--- a/mobile/app/send/index.tsx
+++ b/mobile/app/send/index.tsx
@@ -1,0 +1,295 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+
+type ActivityItem = {
+  id: string;
+  recipient: string;
+  amount: string;
+  asset: string;
+  status: 'unclaimed' | 'claimed' | 'expired';
+  createdAt: string;
+};
+
+const MOCK_ACTIVITY: ActivityItem[] = [
+  {
+    id: 'tr_001',
+    recipient: 'Nene Obi',
+    amount: '24.50',
+    asset: 'USDC',
+    status: 'unclaimed',
+    createdAt: '2026-04-26',
+  },
+  {
+    id: 'tr_002',
+    recipient: 'Musa Bello',
+    amount: '5.00',
+    asset: 'XLM',
+    status: 'claimed',
+    createdAt: '2026-04-25',
+  },
+  {
+    id: 'tr_003',
+    recipient: 'Ada Nwosu',
+    amount: '8.10',
+    asset: 'USDC',
+    status: 'expired',
+    createdAt: '2026-04-22',
+  },
+];
+
+const statusColors: Record<ActivityItem['status'], string> = {
+  unclaimed: '#F59E0B',
+  claimed: '#22C55E',
+  expired: '#EF4444',
+};
+
+const SkeletonCard = () => <View style={styles.skeletonBlock} />;
+
+export default function SenderDashboardScreen() {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(true);
+  const [activity, setActivity] = useState<ActivityItem[]>([]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setActivity(MOCK_ACTIVITY);
+      setIsLoading(false);
+    }, 900);
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  const summary = useMemo(() => {
+    const totalSent = activity.reduce((sum, item) => {
+      const value = Number.parseFloat(item.amount);
+      return Number.isNaN(value) ? sum : sum + value;
+    }, 0);
+
+    return {
+      totalTransfers: activity.length,
+      activeClaims: activity.filter((item) => item.status === 'unclaimed').length,
+      totalSent: totalSent.toFixed(2),
+    };
+  }, [activity]);
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView contentContainerStyle={styles.content}>
+        <Text style={styles.heading}>Sender Dashboard</Text>
+        <Text style={styles.subheading}>
+          Track your transfer activity and create new claims in one place.
+        </Text>
+
+        <View style={styles.cardGrid}>
+          {isLoading ? (
+            <>
+              <SkeletonCard />
+              <SkeletonCard />
+              <SkeletonCard />
+            </>
+          ) : (
+            <>
+              <View style={styles.summaryCard}>
+                <Text style={styles.cardLabel}>Total Sent</Text>
+                <Text style={styles.cardValue}>{summary.totalSent}</Text>
+              </View>
+              <View style={styles.summaryCard}>
+                <Text style={styles.cardLabel}>Transfers</Text>
+                <Text style={styles.cardValue}>{summary.totalTransfers}</Text>
+              </View>
+              <View style={styles.summaryCard}>
+                <Text style={styles.cardLabel}>Active Claims</Text>
+                <Text style={styles.cardValue}>{summary.activeClaims}</Text>
+              </View>
+            </>
+          )}
+        </View>
+
+        <TouchableOpacity
+          style={styles.primaryButton}
+          onPress={() => router.push('/send/create')}
+        >
+          <Text style={styles.primaryButtonText}>Create Transfer</Text>
+        </TouchableOpacity>
+
+        <View style={styles.sectionHeaderRow}>
+          <Text style={styles.sectionHeading}>Recent Activity</Text>
+        </View>
+
+        {isLoading ? (
+          <View style={styles.activityList}>
+            <SkeletonCard />
+            <SkeletonCard />
+            <SkeletonCard />
+          </View>
+        ) : activity.length === 0 ? (
+          <View style={styles.emptyState}>
+            <Text style={styles.emptyTitle}>No activity yet</Text>
+            <Text style={styles.emptySubtitle}>
+              Create your first transfer to see activity here.
+            </Text>
+          </View>
+        ) : (
+          <View style={styles.activityList}>
+            {activity.map((item) => (
+              <View key={item.id} style={styles.activityItem}>
+                <View>
+                  <Text style={styles.activityRecipient}>{item.recipient}</Text>
+                  <Text style={styles.activityMeta}>{item.createdAt}</Text>
+                </View>
+                <View style={styles.activityRight}>
+                  <Text style={styles.activityAmount}>
+                    {item.amount} {item.asset}
+                  </Text>
+                  <Text
+                    style={[
+                      styles.activityStatus,
+                      { color: statusColors[item.status] },
+                    ]}
+                  >
+                    {item.status}
+                  </Text>
+                </View>
+              </View>
+            ))}
+          </View>
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#0F172A',
+  },
+  content: {
+    padding: 20,
+    gap: 14,
+  },
+  heading: {
+    color: '#FFFFFF',
+    fontSize: 28,
+    fontWeight: '700',
+  },
+  subheading: {
+    color: '#94A3B8',
+    fontSize: 14,
+    lineHeight: 21,
+  },
+  cardGrid: {
+    flexDirection: 'row',
+    gap: 10,
+    marginTop: 4,
+  },
+  summaryCard: {
+    flex: 1,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#334155',
+    backgroundColor: '#111827',
+    padding: 12,
+    minHeight: 96,
+    justifyContent: 'space-between',
+  },
+  cardLabel: {
+    color: '#94A3B8',
+    fontSize: 13,
+  },
+  cardValue: {
+    color: '#F8FAFC',
+    fontSize: 22,
+    fontWeight: '700',
+  },
+  primaryButton: {
+    borderRadius: 12,
+    paddingVertical: 14,
+    alignItems: 'center',
+    backgroundColor: '#2563EB',
+  },
+  primaryButtonText: {
+    color: '#FFFFFF',
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  sectionHeaderRow: {
+    marginTop: 2,
+  },
+  sectionHeading: {
+    color: '#E2E8F0',
+    fontSize: 18,
+    fontWeight: '700',
+  },
+  activityList: {
+    gap: 10,
+  },
+  activityItem: {
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#334155',
+    backgroundColor: '#111827',
+    padding: 12,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  activityRecipient: {
+    color: '#FFFFFF',
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  activityMeta: {
+    color: '#64748B',
+    marginTop: 2,
+    fontSize: 12,
+  },
+  activityRight: {
+    alignItems: 'flex-end',
+    gap: 4,
+  },
+  activityAmount: {
+    color: '#F8FAFC',
+    fontWeight: '700',
+  },
+  activityStatus: {
+    textTransform: 'capitalize',
+    fontSize: 12,
+    fontWeight: '700',
+  },
+  emptyState: {
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#334155',
+    backgroundColor: '#111827',
+    padding: 18,
+    alignItems: 'center',
+  },
+  emptyTitle: {
+    color: '#E2E8F0',
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  emptySubtitle: {
+    marginTop: 6,
+    color: '#94A3B8',
+    textAlign: 'center',
+    lineHeight: 20,
+  },
+  skeletonBlock: {
+    height: 88,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#334155',
+    backgroundColor: '#1E293B',
+    flex: 1,
+  },
+});


### PR DESCRIPTION
## Summary
- add a dedicated claim success confirmation screen with animation, transaction summary, share action, explorer link, and done navigation
- add a sender dashboard screen with transfer summary cards, recent activity list, create transfer CTA, and loading skeleton states
- wire mobile navigation for new `send` and `claim/success` routes and redirect onboarded users to sender dashboard

## Issue links
Closes #52
Closes #53
Closes #52
Closes #53