### PR TITLE
feat: post-claim share Bridgelet prompt for recipients

### DIFF
--- a/frontend/app/claim/[token]/page.tsx
+++ b/frontend/app/claim/[token]/page.tsx
@@ -1,4 +1,5 @@
 import { PageShell } from '@/components/page-shell';
+import { SharePrompt } from '@/components/share-prompt';
 import { publicEnv } from '@/lib/env';
 
 type ClaimPageProps = {
@@ -23,6 +24,7 @@ export default async function ClaimPage({ params }: ClaimPageProps) {
           <dd>{publicEnv.NEXT_PUBLIC_SUPPORT_EMAIL}</dd>
         </div>
       </dl>
+      <SharePrompt appUrl={publicEnv.NEXT_PUBLIC_APP_URL} />
     </PageShell>
   );
 }

--- a/frontend/components/share-prompt.tsx
+++ b/frontend/components/share-prompt.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useState } from 'react';
+
+type SharePromptProps = {
+  appUrl: string;
+};
+
+export function SharePrompt({ appUrl }: SharePromptProps) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(appUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // clipboard API unavailable — no-op
+    }
+  }
+
+  return (
+    <div className="mt-8 rounded-xl border border-slate-100 bg-slate-50 p-5">
+      <p className="text-sm font-medium text-slate-800">
+        Do you send payments to your team or community?
+      </p>
+      <p className="mt-1 text-sm text-slate-600">
+        Bridgelet lets anyone send funds to recipients who have no crypto wallet — they claim
+        directly from a link. Share it with employers, payroll managers, or community leaders.
+      </p>
+      <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:items-center">
+        <code className="flex-1 rounded-md border border-slate-200 bg-white px-3 py-1.5 text-xs text-slate-700 break-all">
+          {appUrl}
+        </code>
+        <button
+          onClick={handleCopy}
+          className="shrink-0 rounded-md bg-slate-900 px-4 py-1.5 text-sm font-medium text-white transition hover:bg-slate-700"
+          type="button"
+        >
+          {copied ? 'Copied!' : 'Copy link'}
+        </button>
+      </div>
+      <div className="mt-3 flex gap-4">
+        <a
+          href={`https://twitter.com/intent/tweet?text=${encodeURIComponent('Just received a crypto payment via Bridgelet — the recipient needed no wallet. Check it out:')}&url=${encodeURIComponent(appUrl)}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs text-slate-500 underline underline-offset-2 hover:text-slate-800"
+        >
+          Share on X
+        </a>
+        <a
+          href={`https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(appUrl)}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs text-slate-500 underline underline-offset-2 hover:text-slate-800"
+        >
+          Share on LinkedIn
+        </a>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

After a successful claim, recipients now see a subtle **Share Bridgelet** section at the bottom of the claim page. This targets recipients who are employers, payroll managers, or community leaders that could become senders themselves.

**Changes:**
- New `frontend/components/share-prompt.tsx` — client component with copy-link button (clipboard API) and share links for X and LinkedIn
- Updated `frontend/app/claim/[token]/page.tsx` — renders `<SharePrompt appUrl={publicEnv.NEXT_PUBLIC_APP_URL} />` after the claim detail list

## How It Looks

The share section appears below the claim details with:
- A one-line pitch explaining Bridgelet for senders
- The app URL in a code block with a **Copy link** button (shows "Copied!" for 2 s)
- Share links for X (Twitter) and LinkedIn using native share intents
- Tailwind styling matching the existing page shell (slate colour palette, rounded-xl card)

## Test Plan

- [ ] Visit `/claim/any-token` — Share Bridgelet section is visible below the claim token info
- [ ] Click **Copy link** — button shows "Copied!" then resets; clipboard contains `NEXT_PUBLIC_APP_URL`
- [ ] Click "Share on X" / "Share on LinkedIn" — opens correct share URLs in a new tab
- [ ] Section is absent on all other pages (send, home)

closes #116