### PR TITLE
feat: define and implement wallet-based sender auth for /send

### DIFF
--- a/docs/sender-auth-model.md
+++ b/docs/sender-auth-model.md
@@ -1,0 +1,39 @@
+# Sender Auth Model for `/send`
+
+## Decision
+
+**Option B — Wallet-based auth via Freighter** is the chosen approach for the `/send` page.
+
+## Options Evaluated
+
+| Option | Description | Verdict |
+|--------|-------------|---------|
+| A — API key in env | Caller includes a static `X-API-Key` header from `.env`. Suits backend org integrations. | ❌ Rejected for browser UI — key would leak in the JS bundle. |
+| B — Wallet-based auth (Freighter) | Sender connects Freighter browser extension. The public key identifies them; transaction signing is the implicit proof of auth. | ✅ **Chosen.** Native to Stellar, non-custodial, already supported by `lib/wallet.ts`. |
+| C — No auth (open send) | `/send` is fully open with no identity check. | ❌ Rejected for MVP — unmitigated spam/abuse risk without rate-limiting. |
+
+## How It Works
+
+1. The `/send` page renders a `WalletConnect` component (`frontend/components/wallet-connect.tsx`).
+2. The user clicks **Connect Freighter Wallet** — this opens the Freighter extension popup.
+3. On approval, the sender's Stellar public key is returned.
+4. When the sender creates a payment intent, the Bridgelet SDK signs the transaction with the connected key, which serves as the auth proof — no JWT is issued or stored.
+
+## Security Notes
+
+- No session token or JWT is created. Wallet ownership is proven at transaction-signing time.
+- LOBSTR (mobile wallet) is supported via a paste-your-public-key fallback already wired in `lib/wallet.ts`.
+- For server-side / org integrations that call the Bridgelet API from a backend, an env-level API key (Option A) remains viable. That flow should be documented separately in an integration guide.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `frontend/components/wallet-connect.tsx` | New — Freighter connect button with connected/error states |
+| `frontend/app/send/page.tsx` | Updated — renders `WalletConnect` before the API config display |
+
+## References
+
+- `frontend/lib/wallet.ts` — `connectFreighter()` and wallet persistence helpers
+- [Freighter browser extension](https://freighter.app)
+- [Freighter JS API docs](https://docs.freighter.app)

--- a/frontend/app/send/page.tsx
+++ b/frontend/app/send/page.tsx
@@ -1,22 +1,26 @@
 import { PageShell } from '@/components/page-shell';
+import { WalletConnect } from '@/components/wallet-connect';
 import { publicEnv } from '@/lib/env';
 
 export default function SendPage() {
   return (
     <PageShell
       title="Sender Flow"
-      description="Placeholder sender journey for creating and funding a payment claim."
+      description="Connect your Stellar wallet to authorise payments. Auth is wallet-based — no password or JWT required."
     >
-      <dl className="space-y-4 text-sm text-slate-700">
-        <div>
-          <dt className="font-medium text-slate-900">API Base URL</dt>
-          <dd>{publicEnv.NEXT_PUBLIC_API_BASE_URL}</dd>
-        </div>
-        <div>
-          <dt className="font-medium text-slate-900">Network</dt>
-          <dd>{publicEnv.NEXT_PUBLIC_CRYPTO_NETWORK}</dd>
-        </div>
-      </dl>
+      <div className="space-y-6">
+        <WalletConnect />
+        <dl className="space-y-4 text-sm text-slate-700">
+          <div>
+            <dt className="font-medium text-slate-900">API Base URL</dt>
+            <dd>{publicEnv.NEXT_PUBLIC_API_BASE_URL}</dd>
+          </div>
+          <div>
+            <dt className="font-medium text-slate-900">Network</dt>
+            <dd>{publicEnv.NEXT_PUBLIC_CRYPTO_NETWORK}</dd>
+          </div>
+        </dl>
+      </div>
     </PageShell>
   );
 }

--- a/frontend/components/wallet-connect.tsx
+++ b/frontend/components/wallet-connect.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useState } from 'react';
+import { connectFreighter, type ConnectedWallet } from '@/lib/wallet';
+
+type WalletConnectProps = {
+  onConnected?: (wallet: ConnectedWallet) => void;
+};
+
+export function WalletConnect({ onConnected }: WalletConnectProps) {
+  const [wallet, setWallet] = useState<ConnectedWallet | null>(null);
+  const [status, setStatus] = useState<'idle' | 'connecting' | 'error'>('idle');
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleConnect() {
+    setStatus('connecting');
+    setError(null);
+    try {
+      const connected = await connectFreighter();
+      setWallet(connected);
+      setStatus('idle');
+      onConnected?.(connected);
+    } catch (err) {
+      setStatus('error');
+      setError(err instanceof Error ? err.message : 'Failed to connect wallet.');
+    }
+  }
+
+  if (wallet) {
+    return (
+      <div className="rounded-lg border border-green-200 bg-green-50 px-4 py-3">
+        <p className="text-sm font-medium text-green-800">Wallet connected</p>
+        <p className="mt-0.5 break-all font-mono text-xs text-green-700">{wallet.publicKey}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <button
+        onClick={handleConnect}
+        disabled={status === 'connecting'}
+        className="rounded-lg bg-slate-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-700 disabled:opacity-60"
+        type="button"
+      >
+        {status === 'connecting' ? 'Connecting…' : 'Connect Freighter Wallet'}
+      </button>
+      {status === 'error' && error && (
+        <p className="text-sm text-red-600">{error}</p>
+      )}
+      <p className="text-xs text-slate-500">
+        Auth is wallet-based — signing a transaction with your Freighter key proves you control
+        this address. No password or JWT is required.{' '}
+        <a
+          href="https://docs.freighter.app"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline underline-offset-2 hover:text-slate-800"
+        >
+          Install Freighter
+        </a>
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Decides, documents, and implements the sender auth model for `/send`. Three options were evaluated; **wallet-based auth via Freighter (Option B)** was chosen.

**Changes:**
- New `docs/sender-auth-model.md` — decision record with options table, rationale, security notes, and file index
- New `frontend/components/wallet-connect.tsx` — Freighter connect button with idle / connecting / connected / error states
- Updated `frontend/app/send/page.tsx` — renders `<WalletConnect />` before the API config display

## Auth Decision Summary

| Option | Verdict |
|--------|---------|
| A — API key in env | ❌ Leaks in browser bundle |
| **B — Freighter wallet (chosen)** | ✅ Non-custodial, native to Stellar, no JWT needed |
| C — No auth | ❌ Unmitigated spam risk |

The wallet public key identifies the sender; signing a payment transaction is the implicit auth proof.

## Test Plan

- [ ] Visit `/send` — **Connect Freighter Wallet** button is visible
- [ ] Without Freighter installed — button shows an error: "Freighter extension not found"
- [ ] With Freighter installed and approved — wallet card shows the connected public key
- [ ] `docs/sender-auth-model.md` renders correctly on GitHub with the options table
- [ ] No JWT, cookie, or API key is set anywhere in the flow

closes #102