### PR TITLE
feat: wire openapi-typescript type generation for Bridgelet API

### DIFF
--- a/frontend/lib/bridgelet.ts
+++ b/frontend/lib/bridgelet.ts
@@ -1,0 +1,75 @@
+/**
+ * Bridgelet API TypeScript types
+ *
+ * These types are manually maintained as a baseline.
+ * Once the SDK exposes an OpenAPI spec at /api/docs-json, regenerate with:
+ *
+ *   npm run generate:types
+ *
+ * See scripts/generate-types.mjs for full instructions.
+ */
+
+// ─── Payment Intent ──────────────────────────────────────────────────────────
+
+/** Request body for POST /send */
+export interface CreatePaymentIntentRequest {
+  /** Stellar public key of the sender (G...) */
+  senderPublicKey: string;
+  /** Amount in stroops (1 XLM = 10_000_000) */
+  amountStroops: string;
+  /** ISO 4217 asset code, e.g. "USDC" or "XLM" */
+  assetCode: string;
+  /** Optional memo attached to the Stellar transaction */
+  memo?: string;
+}
+
+/** Response from POST /send */
+export interface CreatePaymentIntentResponse {
+  /** Unique identifier for this payment intent */
+  intentId: string;
+  /** One-time claim token delivered to the recipient */
+  claimToken: string;
+  /** URL the recipient uses to claim the payment */
+  claimUrl: string;
+  /** ISO 8601 timestamp after which the token expires */
+  expiresAt: string;
+}
+
+// ─── Claim ───────────────────────────────────────────────────────────────────
+
+/** Response from GET /claim/:token */
+export interface ClaimDetailsResponse {
+  /** Whether the claim token is still valid and unclaimed */
+  valid: boolean;
+  /** Amount in stroops */
+  amountStroops: string;
+  /** Asset code */
+  assetCode: string;
+  /** ISO 8601 expiry timestamp */
+  expiresAt: string;
+  /** Optional sender memo */
+  memo?: string;
+}
+
+/** Request body for POST /claim/:token/redeem */
+export interface RedeemClaimRequest {
+  /** Recipient's Stellar public key */
+  recipientPublicKey: string;
+}
+
+/** Response from POST /claim/:token/redeem */
+export interface RedeemClaimResponse {
+  /** Stellar transaction hash */
+  txHash: string;
+  /** Stellar Explorer link for this transaction */
+  explorerUrl: string;
+}
+
+// ─── Error envelope ──────────────────────────────────────────────────────────
+
+/** Standard API error shape returned on 4xx / 5xx responses */
+export interface ApiError {
+  error: string;
+  message: string;
+  statusCode: number;
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "generate:types": "node scripts/generate-types.mjs"
   },
   "dependencies": {
     "next": "^16.0.0",
@@ -18,6 +19,7 @@
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "openapi-typescript": "^7.0.0",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.0.0"
   },

--- a/frontend/scripts/generate-types.mjs
+++ b/frontend/scripts/generate-types.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+/**
+ * Generates TypeScript types from the Bridgelet SDK's OpenAPI spec.
+ *
+ * Prerequisites:
+ *   npm install -D openapi-typescript   (already in devDependencies)
+ *
+ * Usage:
+ *   BRIDGELET_API_URL=http://localhost:4000 npm run generate:types
+ *   # or with defaults from .env:
+ *   npm run generate:types
+ *
+ * The SDK must expose GET /api/docs-json returning a valid OpenAPI 3.x document.
+ * Generated output overwrites frontend/lib/bridgelet.ts.
+ */
+
+import { execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Resolve API URL from env, falling back to local dev default
+const apiUrl =
+  process.env.BRIDGELET_API_URL ??
+  process.env.NEXT_PUBLIC_API_BASE_URL ??
+  'http://localhost:4000';
+
+const specUrl = `${apiUrl}/api/docs-json`;
+const outFile = resolve(__dirname, '../lib/bridgelet.ts');
+
+console.log(`Fetching OpenAPI spec from: ${specUrl}`);
+console.log(`Writing types to:           ${outFile}`);
+
+try {
+  execSync(`npx openapi-typescript "${specUrl}" -o "${outFile}"`, { stdio: 'inherit' });
+  console.log('\nType generation complete.');
+  console.log('Tip: commit the updated lib/bridgelet.ts so types stay in sync with the API.');
+} catch (err) {
+  console.error('\nGeneration failed:', err instanceof Error ? err.message : err);
+  console.error('Ensure the SDK is running and GET /api/docs-json returns a valid OpenAPI 3.x spec.');
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Sets up the OpenAPI-to-TypeScript type generation pipeline and introduces a manually-maintained baseline of API types that will be replaced by auto-generated output once the SDK exposes `/api/docs-json`.

**Changes:**
- New `frontend/lib/bridgelet.ts` — typed interfaces for `CreatePaymentIntentRequest/Response`, `ClaimDetailsResponse`, `RedeemClaimRequest/Response`, and `ApiError`. Includes a header comment directing developers to regenerate via `npm run generate:types` once the SDK is live.
- New `frontend/scripts/generate-types.mjs` — Node ESM script that calls `openapi-typescript` against `$BRIDGELET_API_URL/api/docs-json` and writes output to `lib/bridgelet.ts`. Reads `BRIDGELET_API_URL` or `NEXT_PUBLIC_API_BASE_URL` env vars; defaults to `http://localhost:4000`.
- Updated `frontend/package.json` — adds `"generate:types": "node scripts/generate-types.mjs"` script and `"openapi-typescript": "^7.0.0"` devDependency.

## How to Use (once SDK is ready)

```bash
# Start the SDK locally
# NEXT_PUBLIC_API_BASE_URL is already set in .env

cd frontend
npm install
npm run generate:types
# lib/bridgelet.ts is now replaced with generated types
git add lib/bridgelet.ts && git commit -m "chore: regenerate API types from OpenAPI spec"
```

## Test Plan

- [ ] `frontend/lib/bridgelet.ts` imports compile without errors (`npm run typecheck`)
- [ ] `frontend/scripts/generate-types.mjs` is executable and prints helpful error when SDK is not running
- [ ] `frontend/package.json` contains `generate:types` script and `openapi-typescript` devDep
- [ ] Running `npm run generate:types` against a running SDK overwrites `lib/bridgelet.ts` with generated types

closes #98