### PR TITLE
feat: set up MSW for all API endpoints

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
 import './globals.css';
 import { DevToolbar } from '@/components/dev-toolbar';
+import { MockProvider } from '@/components/mock-provider';
 
 export const metadata: Metadata = {
   title: 'Bridgelet Payments',
@@ -21,6 +22,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
       <body>
         {children}
         {isDev && <DevToolbar />}
+        {isDev && <MockProvider />}
       </body>
     </html>
   );

--- a/frontend/components/mock-provider.tsx
+++ b/frontend/components/mock-provider.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export function MockProvider() {
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'development') {
+      import('@/mocks').then(({ initMocks }) => initMocks());
+    }
+  }, []);
+
+  return null;
+}

--- a/frontend/mocks/browser.ts
+++ b/frontend/mocks/browser.ts
@@ -1,11 +1,6 @@
 import { setupWorker } from 'msw/browser';
-import { horizonHandlers } from './handlers/horizon';
 import { accountHandlers } from './handlers/accounts';
+import { horizonHandlers } from './handlers/horizon';
+import { claimsHandlers } from './handlers/claims';
 
-/**
- * MSW service worker for browser environments.
- *
- * Start this once in development to intercept fetch/XHR calls.
- * The worker is only initialised when this module is imported.
- */
-export const worker = setupWorker(...accountHandlers);
+export const worker = setupWorker(...accountHandlers, ...horizonHandlers, ...claimsHandlers);

--- a/frontend/mocks/handlers/claims.ts
+++ b/frontend/mocks/handlers/claims.ts
@@ -1,0 +1,34 @@
+import { http, HttpResponse } from 'msw';
+
+export const claimsHandlers = [
+  http.get('/claims/:token', ({ params }) => {
+    const { token } = params as { token: string };
+    return HttpResponse.json({
+      token,
+      amount: '100.0000000',
+      asset: 'XLM',
+      status: 'pending',
+      expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+    });
+  }),
+
+  http.post('/claims/initiate', async () => {
+    return HttpResponse.json(
+      {
+        id: crypto.randomUUID(),
+        claimToken: crypto.randomUUID().replace(/-/g, ''),
+        status: 'created',
+        createdAt: new Date().toISOString(),
+      },
+      { status: 201 },
+    );
+  }),
+
+  http.post('/claims/redeem', async () => {
+    return HttpResponse.json({
+      success: true,
+      sweep_status: 'stub',
+      redeemedAt: new Date().toISOString(),
+    });
+  }),
+];


### PR DESCRIPTION
Closes #89

## Changes
- Add claims handlers (GET /claims/:token, POST /claims/initiate, POST /claims/redeem)
- Wire all handlers (account, horizon, claims) into the MSW service worker
- Add MockProvider client component to bootstrap MSW in development