### PR TITLE
feat: ARIA live region for claim status updates

### DIFF
--- a/frontend/components/claim-status-card.tsx
+++ b/frontend/components/claim-status-card.tsx
@@ -242,6 +242,9 @@ export function ClaimStatusCard({
   return (
     <article
       aria-label={`Claim status: ${status}`}
+      aria-live="polite"
+      aria-atomic="true"
+      aria-relevant="additions text"
       className={`rounded-xl border-2 ${borderColors[status]} bg-white p-5 shadow-sm space-y-4`}
     >
       <header className="flex items-center justify-between">


### PR DESCRIPTION
Closes #88

## Changes
- Add aria-live="polite" and aria-atomic="true" to the claim status card
- Screen readers now announce status changes (e.g. "Claim processing... Claim successful!") without requiring a page refresh