### PR TITLE
feat: MSW mock for POST /claims/redeem with sweep stub

### DIFF
--- a/frontend/components/claim-status-card.tsx
+++ b/frontend/components/claim-status-card.tsx
@@ -19,6 +19,8 @@ export interface ClaimStatusCardProps {
   memo?: string;
   /** Called when the recipient taps "Claim now". */
   onClaim?: () => void | Promise<void>;
+  /** Developer-facing note from the API (e.g. sweep_status stub message). */
+  sweepNote?: string;
   /** Support contact email shown in the expired state. */
   supportEmail?: string;
 }
@@ -68,7 +70,8 @@ function AvailablePanel({
   expiresAt,
   memo,
   onClaim,
-}: Pick<ClaimStatusCardProps, 'amountStroops' | 'assetCode' | 'expiresAt' | 'memo' | 'onClaim'>) {
+  sweepNote,
+}: Pick<ClaimStatusCardProps, 'amountStroops' | 'assetCode' | 'expiresAt' | 'memo' | 'onClaim' | 'sweepNote'>) {
   const [claiming, setClaiming] = useState(false);
   const [done, setDone] = useState(false);
 
@@ -84,9 +87,16 @@ function AvailablePanel({
 
   if (done) {
     return (
-      <p role="status" className="text-sm font-medium text-green-700">
-        Claim submitted! Check your wallet for the incoming transfer.
-      </p>
+      <div className="space-y-2">
+        <p role="status" className="text-sm font-medium text-green-700">
+          Claim submitted! Check your wallet for the incoming transfer.
+        </p>
+        {sweepNote && (
+          <p className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-2">
+            🛠 Dev note: {sweepNote}
+          </p>
+        )}
+      </div>
     );
   }
 
@@ -225,6 +235,7 @@ export function ClaimStatusCard({
   expiresAt,
   memo,
   onClaim,
+  sweepNote,
   supportEmail,
 }: ClaimStatusCardProps) {
   const headers: Record<ClaimStatus, string> = {
@@ -258,6 +269,7 @@ export function ClaimStatusCard({
           expiresAt={expiresAt}
           memo={memo}
           onClaim={onClaim}
+          sweepNote={sweepNote}
         />
       )}
       {status === 'claimed' && <ClaimedPanel />}

--- a/frontend/mocks/browser.ts
+++ b/frontend/mocks/browser.ts
@@ -1,6 +1,7 @@
 import { setupWorker } from 'msw/browser';
 import { horizonHandlers } from './handlers/horizon';
 import { accountHandlers } from './handlers/accounts';
+import { claimsHandlers } from './handlers/claims';
 
 /**
  * MSW service worker for browser environments.
@@ -8,4 +9,4 @@ import { accountHandlers } from './handlers/accounts';
  * Start this once in development to intercept fetch/XHR calls.
  * The worker is only initialised when this module is imported.
  */
-export const worker = setupWorker(...accountHandlers);
+export const worker = setupWorker(...accountHandlers, ...horizonHandlers, ...claimsHandlers);

--- a/frontend/mocks/handlers/claims.ts
+++ b/frontend/mocks/handlers/claims.ts
@@ -1,0 +1,12 @@
+import { http, HttpResponse } from 'msw';
+
+export const claimsHandlers = [
+  http.post('/claims/redeem', () =>
+    HttpResponse.json({
+      txHash: 'mock-tx-hash-stub',
+      explorerUrl: 'https://stellar.expert/explorer/testnet/tx/mock-tx-hash-stub',
+      sweep_status: 'stub',
+      sweepNote: 'Sweep is stubbed in MVP. Funds remain in the ephemeral account.',
+    }),
+  ),
+];


### PR DESCRIPTION
Closes #91

## Changes
- Add `POST /claims/redeem` MSW handler returning `sweep_status: 'stub'` and `sweepNote`
- Wire `claimsHandlers` into the MSW service worker
- Surface `sweepNote` in `ClaimStatusCard` as a dev-facing note after a successful claim