### PR TITLE
feat: add claim shortener, sandbox page, and docs setup

### DIFF
--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -1,0 +1,36 @@
+---
+title: Architecture Overview
+description: System architecture of the Bridgelet platform
+---
+
+# Architecture Overview
+
+## System Flow
+
+```mermaid
+graph LR
+  FE[bridgelet<br/>Next.js frontend]
+  SDK[bridgelet-sdk<br/>NestJS backend]
+  CORE[bridgelet-core<br/>Soroban contracts]
+  STELLAR[Stellar Network]
+
+  FE -->|POST /send| SDK
+  FE -->|POST /claims/redeem| SDK
+  SDK -->|invoke contract| CORE
+  CORE -->|on-chain tx| STELLAR
+  SDK -->|horizon API| STELLAR
+```
+
+## Components
+
+### bridgelet (frontend)
+Next.js app serving the sender send-flow and recipient claim flow.
+
+### bridgelet-sdk
+NestJS service managing ephemeral account lifecycle, claim authentication, and webhook delivery.
+
+### bridgelet-core
+Soroban smart contracts enforcing on-chain restrictions: funding source, amount cap, expiry, and sweep.
+
+### Stellar Network
+The bridgelet-core contracts run on Stellar's Soroban environment (testnet and mainnet).

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,0 +1,25 @@
+---
+title: Bridgelet Docs
+description: Documentation for the Bridgelet ephemeral-accounts platform
+---
+
+# Bridgelet Documentation
+
+Bridgelet enables ephemeral Stellar accounts for onboarding non-crypto users.
+
+## Getting Started
+
+- [Integration Guide](./integration-guide) — SDK installation, claim links, webhooks
+- [Architecture Overview](./architecture) — system design and data flow
+- [Security Model](./security-model) — key management and sweep logic
+
+## Packages
+
+| Package | Description |
+|---------|-------------|
+| `bridgelet-core` | Soroban smart contracts |
+| `bridgelet-sdk` | NestJS backend SDK |
+| `bridgelet` (this repo) | Next.js frontend + docs |
+
+> **Note:** Prose docs are authored in MDX. PDFs in this directory are provided
+> as supplementary references.

--- a/frontend/app/sandbox/claim-test/page.tsx
+++ b/frontend/app/sandbox/claim-test/page.tsx
@@ -1,0 +1,31 @@
+// #124 – Sandbox page for generating and claiming test tokens (dev/staging only)
+import { redirect } from 'next/navigation';
+
+export default function ClaimTestPage() {
+  if (process.env.NODE_ENV === 'production') {
+    redirect('/');
+  }
+
+  const demoToken = 'sandbox_demo_token_' + Date.now();
+
+  return (
+    <main className="p-8 max-w-lg mx-auto space-y-6">
+      <h1 className="text-xl font-bold">Claim Test Sandbox</h1>
+      <p className="text-sm text-slate-500">
+        Only visible in development and staging environments.
+      </p>
+      <div className="rounded-lg border p-4 space-y-2 bg-slate-50">
+        <p className="text-xs font-mono break-all text-slate-600">Token: {demoToken}</p>
+        <a
+          href={`/claim/${demoToken}`}
+          className="inline-block rounded bg-slate-900 px-4 py-2 text-sm text-white hover:bg-slate-700"
+        >
+          Claim this test token →
+        </a>
+      </div>
+      <p className="text-xs text-slate-400">
+        Append <code>?state=claimed</code> or <code>?state=expired</code> to test other states.
+      </p>
+    </main>
+  );
+}

--- a/frontend/lib/shorten.ts
+++ b/frontend/lib/shorten.ts
@@ -1,0 +1,20 @@
+// #121 – Claim link shortener utility for SMS-friendly URLs
+const BASE62 = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+
+export function encodeShortToken(token: string): string {
+  let hash = 0;
+  for (let i = 0; i < token.length; i++) {
+    hash = (hash * 31 + token.charCodeAt(i)) >>> 0;
+  }
+  let result = '';
+  let n = hash || 1;
+  while (n > 0) {
+    result = (BASE62[n % 62] ?? '0') + result;
+    n = Math.floor(n / 62);
+  }
+  return result.slice(0, 8).padStart(6, '0');
+}
+
+export function buildShortClaimUrl(appUrl: string, token: string): string {
+  return `${appUrl}/c/${encodeShortToken(token)}`;
+}


### PR DESCRIPTION
## Summary

- **Claim link shortener** (`frontend/lib/shorten.ts`) — `encodeShortToken()` hashes a full claim token to a 6–8 char Base62 string; `buildShortClaimUrl()` returns the short URL. Evaluates a Next.js-rewrite approach (no separate redirect service needed for MVP).
- **Sandbox claim-test page** (`frontend/app/sandbox/claim-test/page.tsx`) — `/sandbox/claim-test` generates a demo token and links to the claim flow. Redirects to `/` in production so it is never exposed publicly.
- **Docs index** (`docs/index.mdx`) — entry-point MDX page for the docs site listing all sections and packages; compatible with Nextra or Docusaurus.
- **Architecture MDX** (`docs/architecture.mdx`) — re-authors the architecture PDF as MDX with an embedded Mermaid diagram showing the full bridgelet → bridgelet-sdk → bridgelet-core → Stellar flow.

closes #121
closes #124
closes #125
closes #127