### PR TITLE
feat: add claim error handling, Freighter integration, and analytics

### DIFF
--- a/frontend/components/freighter-connect.tsx
+++ b/frontend/components/freighter-connect.tsx
@@ -1,0 +1,52 @@
+// #115 – Freighter wallet integration with install fallback
+'use client';
+import { useState } from 'react';
+
+type Props = { onAddress: (address: string) => void };
+
+declare global {
+  interface Window {
+    freighter?: { getPublicKey(): Promise<string>; isConnected(): Promise<boolean> };
+  }
+}
+
+export function FreighterConnect({ onAddress }: Props) {
+  const [status, setStatus] = useState<'idle' | 'connecting' | 'error'>('idle');
+  const [error, setError] = useState<string | null>(null);
+
+  async function connect() {
+    if (typeof window === 'undefined' || !window.freighter) {
+      setStatus('error');
+      setError('Freighter is not installed.');
+      return;
+    }
+    setStatus('connecting');
+    setError(null);
+    try {
+      const key = await window.freighter.getPublicKey();
+      onAddress(key);
+      setStatus('idle');
+    } catch {
+      setStatus('error');
+      setError('Failed to connect. Please unlock Freighter and try again.');
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <button type="button" onClick={connect} disabled={status === 'connecting'}
+        className="rounded bg-indigo-600 px-4 py-2 text-sm text-white hover:bg-indigo-700 disabled:opacity-60">
+        {status === 'connecting' ? 'Connecting…' : 'Connect Freighter Wallet'}
+      </button>
+      {status === 'error' && error && (
+        <p className="text-sm text-red-600">
+          {error}{' '}
+          {!window?.freighter && (
+            <a href="https://freighter.app" target="_blank" rel="noopener noreferrer"
+              className="underline">Install Freighter</a>
+          )}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/lib/analytics.ts
+++ b/frontend/lib/analytics.ts
@@ -1,0 +1,31 @@
+// #118 – Privacy-respecting analytics events (Plausible-compatible, no PII)
+type ClaimEvent =
+  | 'claim_page_viewed'
+  | 'claim_initiated'
+  | 'claim_success'
+  | 'claim_error';
+
+type EventProps = Record<string, string | number | boolean>;
+
+function track(event: ClaimEvent, props?: EventProps): void {
+  if (typeof window === 'undefined') return;
+
+  // Plausible custom event API
+  const plausible = (window as unknown as { plausible?: Function }).plausible;
+  if (typeof plausible === 'function') {
+    plausible(event, { props });
+    return;
+  }
+
+  // Fallback: console in development
+  if (process.env.NODE_ENV !== 'production') {
+    console.debug('[analytics]', event, props);
+  }
+}
+
+export const analytics = {
+  claimPageViewed: () => track('claim_page_viewed'),
+  claimInitiated:  () => track('claim_initiated'),
+  claimSuccess:    () => track('claim_success'),
+  claimError:      (reason: string) => track('claim_error', { reason }),
+};

--- a/frontend/lib/claim-errors.ts
+++ b/frontend/lib/claim-errors.ts
@@ -1,0 +1,35 @@
+// #114 – Typed claim failure modes with user-facing messages
+export type ClaimErrorCode =
+  | 'TOKEN_NOT_FOUND'
+  | 'ALREADY_CLAIMED'
+  | 'EXPIRED'
+  | 'INVALID_ADDRESS'
+  | 'NETWORK_ERROR'
+  | 'SWEEP_FAILED';
+
+export class ClaimError extends Error {
+  constructor(public readonly code: ClaimErrorCode, message: string) {
+    super(message);
+    this.name = 'ClaimError';
+  }
+}
+
+const MESSAGES: Record<ClaimErrorCode, string> = {
+  TOKEN_NOT_FOUND:  'This claim link is invalid or no longer exists.',
+  ALREADY_CLAIMED:  'This payment has already been claimed.',
+  EXPIRED:          'This claim link has expired. Contact the sender for a new one.',
+  INVALID_ADDRESS:  'The destination address is not a valid Stellar public key.',
+  NETWORK_ERROR:    'A network error occurred. Please check your connection and try again.',
+  SWEEP_FAILED:     'The transfer could not be completed. Please try again or contact support.',
+};
+
+export function getClaimErrorMessage(code: ClaimErrorCode): string {
+  return MESSAGES[code];
+}
+
+export function toClaimError(status: number): ClaimError {
+  if (status === 404) return new ClaimError('TOKEN_NOT_FOUND', MESSAGES.TOKEN_NOT_FOUND);
+  if (status === 409) return new ClaimError('ALREADY_CLAIMED', MESSAGES.ALREADY_CLAIMED);
+  if (status === 410) return new ClaimError('EXPIRED', MESSAGES.EXPIRED);
+  return new ClaimError('NETWORK_ERROR', MESSAGES.NETWORK_ERROR);
+}


### PR DESCRIPTION
## Summary

- **Claim error handling** (`frontend/lib/claim-errors.ts`) — typed `ClaimErrorCode` union and `ClaimError` class covering all failure modes: `TOKEN_NOT_FOUND`, `ALREADY_CLAIMED`, `EXPIRED`, `INVALID_ADDRESS`, `NETWORK_ERROR`, `SWEEP_FAILED`. `toClaimError(status)` maps HTTP status codes to the right error; `getClaimErrorMessage(code)` returns an actionable user-facing string.
- **Freighter wallet integration** (`frontend/components/freighter-connect.tsx`) — `FreighterConnect` component checks for the Freighter extension at runtime; shows a "Connect" button when installed, and a "Freighter not installed" message with an install link when absent. Calls `onAddress(key)` on successful connection.
- **Analytics events** (`frontend/lib/analytics.ts`) — `analytics.claimPageViewed/claimInitiated/claimSuccess/claimError()` send events via the Plausible custom event API. No PII or wallet addresses are included in any event. Falls back to `console.debug` in development.

closes #114
closes #115
closes #118