### PR TITLE
feat: add token validation, wallet input, onboarding guide, and redeemClaim

### DIFF
--- a/frontend/components/no-wallet-guide.tsx
+++ b/frontend/components/no-wallet-guide.tsx
@@ -1,0 +1,34 @@
+// #109 – Collapsible no-wallet onboarding guide
+'use client';
+import { useState } from 'react';
+
+export function NoWalletGuide() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="rounded-lg border border-slate-200 text-sm">
+      <button type="button" onClick={() => setOpen(o => !o)}
+        className="flex w-full items-center justify-between px-4 py-3 font-medium text-slate-700 hover:bg-slate-50"
+        aria-expanded={open}>
+        <span>I don&apos;t have a wallet — how do I get one?</span>
+        <span aria-hidden>{open ? '▲' : '▼'}</span>
+      </button>
+      {open && (
+        <div className="border-t px-4 py-4 space-y-3 text-slate-600">
+          <p><strong>Option 1 — Lobstr (mobile, easiest):</strong></p>
+          <ol className="list-decimal list-inside space-y-1 ml-2">
+            <li>Download Lobstr from the App Store or Google Play.</li>
+            <li>Create an account and activate your wallet (requires a small XLM deposit).</li>
+            <li>Copy your Stellar address from the Receive screen and paste it above.</li>
+          </ol>
+          <p><strong>Option 2 — Freighter (browser extension):</strong></p>
+          <ol className="list-decimal list-inside space-y-1 ml-2">
+            <li>Install <a href="https://freighter.app" className="underline" target="_blank" rel="noopener noreferrer">Freighter</a> for Chrome or Firefox.</li>
+            <li>Create a wallet and save your recovery phrase safely.</li>
+            <li>Click <em>Connect Freighter</em> above to auto-fill your address.</li>
+          </ol>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/wallet-address-input.tsx
+++ b/frontend/components/wallet-address-input.tsx
@@ -1,0 +1,48 @@
+// #108 – Stellar wallet address input with G... format validation
+'use client';
+import { useState } from 'react';
+
+const STELLAR_ADDRESS = /^G[A-Z2-7]{55}$/;
+
+type Props = { onValid: (address: string) => void };
+
+export function WalletAddressInput({ onValid }: Props) {
+  const [value, setValue] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const v = e.target.value.trim();
+    setValue(v);
+    setError(null);
+    if (v && STELLAR_ADDRESS.test(v)) onValid(v);
+  }
+
+  function handleBlur() {
+    if (value && !STELLAR_ADDRESS.test(value)) {
+      setError('Enter a valid Stellar address (starts with G, 56 characters).');
+    }
+  }
+
+  return (
+    <div className="space-y-1">
+      <label htmlFor="wallet-address" className="block text-sm font-medium text-slate-700">
+        Your Stellar wallet address
+      </label>
+      <input id="wallet-address" type="text" value={value} autoComplete="off"
+        onChange={handleChange} onBlur={handleBlur}
+        placeholder="G..."
+        className="w-full rounded-lg border px-3 py-2 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        aria-describedby={error ? 'wallet-error' : undefined}
+      />
+      {error && <p id="wallet-error" role="alert" className="text-xs text-red-600">{error}</p>}
+      <p className="text-xs text-slate-500">
+        Don&apos;t have a wallet?{' '}
+        <a href="https://lobstr.co" target="_blank" rel="noopener noreferrer"
+          className="underline hover:text-slate-800">Get Lobstr</a>
+        {' or '}
+        <a href="https://freighter.app" target="_blank" rel="noopener noreferrer"
+          className="underline hover:text-slate-800">Freighter</a>.
+      </p>
+    </div>
+  );
+}

--- a/frontend/lib/redeem.ts
+++ b/frontend/lib/redeem.ts
@@ -1,0 +1,29 @@
+// #110 – redeemClaim() SDK wrapper for POST /claims/redeem
+import type { RedeemClaimRequest, RedeemClaimResponse, ApiError } from '@/lib/bridgelet';
+import { publicEnv } from '@/lib/env';
+
+export const SWEEP_STUB_WARNING =
+  'Note: fund sweep is running in MVP stub mode. Tokens are reserved but not yet transferred on-chain.';
+
+export async function redeemClaim(
+  token: string,
+  destinationAddress: string,
+): Promise<RedeemClaimResponse> {
+  const body: RedeemClaimRequest = { recipientPublicKey: destinationAddress };
+
+  const res = await fetch(
+    `${publicEnv.NEXT_PUBLIC_API_BASE_URL}/claims/${encodeURIComponent(token)}/redeem`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+  );
+
+  if (!res.ok) {
+    const err: ApiError = await res.json();
+    throw new Error(err.message ?? `Redeem failed with status ${res.status}`);
+  }
+
+  return res.json() as Promise<RedeemClaimResponse>;
+}

--- a/frontend/lib/validate-token.ts
+++ b/frontend/lib/validate-token.ts
@@ -1,0 +1,16 @@
+// #106 – Client-side claim token format validation
+const TOKEN_PATTERN = /^[A-Za-z0-9_-]{16,128}$/;
+
+export type TokenValidationResult =
+  | { valid: true }
+  | { valid: false; reason: string };
+
+export function validateClaimToken(token: unknown): TokenValidationResult {
+  if (typeof token !== 'string' || token.trim().length === 0) {
+    return { valid: false, reason: 'No claim token found in this link.' };
+  }
+  if (!TOKEN_PATTERN.test(token)) {
+    return { valid: false, reason: 'This claim link appears to be invalid or corrupted.' };
+  }
+  return { valid: true };
+}


### PR DESCRIPTION
## Summary

- **Token format validation** (`frontend/lib/validate-token.ts`) — `validateClaimToken()` checks the token is a non-empty alphanumeric/dash/underscore string (16–128 chars) before any API call. Returns a typed result with an actionable error reason for malformed tokens.
- **Wallet address input** (`frontend/components/wallet-address-input.tsx`) — accessible labeled input that validates Stellar address format (`G...` 56 chars) on blur. Shows field-level error via `role="alert"`. Includes "Don't have a wallet?" links to Lobstr and Freighter.
- **No-wallet onboarding guide** (`frontend/components/no-wallet-guide.tsx`) — collapsible section with step-by-step instructions for creating a Lobstr (mobile) or Freighter (browser extension) wallet. Toggle uses `aria-expanded` for screen reader compatibility.
- **redeemClaim() SDK wrapper** (`frontend/lib/redeem.ts`) — wraps `POST /claims/:token/redeem` using the existing `RedeemClaimRequest`/`RedeemClaimResponse` types from `lib/bridgelet.ts`. Exports a `SWEEP_STUB_WARNING` constant so the UI can surface the MVP stub notice.

closes #106
closes #108
closes #109
closes #110