### PR TITLE
feat: add request timeout, API key injection, integration guide, and changelog config

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -1,0 +1,16 @@
+{
+  "git": {
+    "commitMessage": "chore: release v${version}",
+    "tagName": "v${version}"
+  },
+  "github": {
+    "release": true,
+    "releaseName": "v${version}"
+  },
+  "plugins": {
+    "@release-it/conventional-changelog": {
+      "preset": "conventionalcommits",
+      "infile": "CHANGELOG.md"
+    }
+  }
+}

--- a/docs/integration-guide.mdx
+++ b/docs/integration-guide.mdx
@@ -1,0 +1,51 @@
+---
+title: Integration Guide
+description: How to integrate Bridgelet into your application
+---
+
+# Integration Guide
+
+## Installation
+
+```bash
+npm install bridgelet-sdk
+```
+
+## 1. Create an Ephemeral Account
+
+```ts
+import { BridgeletSDK } from 'bridgelet-sdk';
+
+const sdk = new BridgeletSDK({ apiKey: process.env.BRIDGELET_API_KEY });
+
+const intent = await sdk.send({
+  senderPublicKey: 'G...',
+  amountStroops: '50000000', // 5 XLM
+  assetCode: 'XLM',
+});
+
+console.log(intent.claimUrl); // share this with the recipient
+```
+
+## 2. Generate a Claim Link
+
+The SDK returns a `claimUrl` in the response. Send it to the recipient via SMS, email, or QR code.
+
+```ts
+const shortUrl = buildShortClaimUrl(process.env.APP_URL, intent.claimToken);
+```
+
+## 3. Handle Webhook Events
+
+```ts
+sdk.on('claim.success', (event) => {
+  console.log('Claimed by', event.recipientPublicKey);
+});
+```
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `BRIDGELET_API_KEY` | Your API key |
+| `NEXT_PUBLIC_API_BASE_URL` | Base URL of the bridgelet-sdk instance |

--- a/frontend/lib/api-client.ts
+++ b/frontend/lib/api-client.ts
@@ -1,0 +1,20 @@
+// #103 – API client that injects X-API-Key header into every request
+import { fetchWithTimeout } from '@/lib/fetch-with-timeout';
+
+const API_KEY = process.env['NEXT_PUBLIC_API_KEY'] ?? '';
+
+if (!API_KEY && process.env.NODE_ENV !== 'development') {
+  console.warn('[bridgelet] NEXT_PUBLIC_API_KEY is not set. API requests may be rejected.');
+}
+
+export async function apiFetch(
+  path: string,
+  options: RequestInit = {},
+): Promise<Response> {
+  const baseUrl = process.env['NEXT_PUBLIC_API_BASE_URL'] ?? '';
+  const headers = new Headers(options.headers);
+  headers.set('Content-Type', 'application/json');
+  if (API_KEY) headers.set('X-API-Key', API_KEY);
+
+  return fetchWithTimeout(`${baseUrl}${path}`, { ...options, headers });
+}

--- a/frontend/lib/fetch-with-timeout.ts
+++ b/frontend/lib/fetch-with-timeout.ts
@@ -1,0 +1,28 @@
+// #101 – fetch wrapper with 10 s AbortController timeout
+export class RequestTimeoutError extends Error {
+  constructor() {
+    super('The request timed out. Please try again.');
+    this.name = 'RequestTimeoutError';
+  }
+}
+
+export async function fetchWithTimeout(
+  url: string,
+  options: RequestInit = {},
+  timeoutMs = 10_000,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(url, { ...options, signal: controller.signal });
+    return response;
+  } catch (err) {
+    if (err instanceof Error && err.name === 'AbortError') {
+      throw new RequestTimeoutError();
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
## Summary

- **Request timeout** (`frontend/lib/fetch-with-timeout.ts`) — `fetchWithTimeout()` wraps `fetch` with an `AbortController` timer (default 10 s). Throws a typed `RequestTimeoutError` on timeout so callers can show a retry prompt instead of hanging indefinitely.
- **API key injection** (`frontend/lib/api-client.ts`) — `apiFetch()` reads `NEXT_PUBLIC_API_KEY` from the environment and injects `X-API-Key` into every request header. Logs a `console.warn` if the key is missing in non-development environments.
- **Integration guide** (`docs/integration-guide.mdx`) — MDX doc covering SDK installation, creating an ephemeral account, generating a claim link, handling webhook events, and a reference table of environment variables.
- **Changelog automation** (`.release-it.json`) — configures `release-it` with `@release-it/conventional-changelog` preset to auto-generate `CHANGELOG.md` entries from conventional commit messages on each release tag.

closes #101
closes #103
closes #128
closes #134