### PR TITLE
feat: claim flow — 429 feedback, page layout, success screen, mobile UX

### DIFF
--- a/frontend/components/claim-status-card.tsx
+++ b/frontend/components/claim-status-card.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useState } from 'react';
+import { RateLimitBanner } from '@/components/rate-limit-banner';
+import { RateLimitError } from '@/lib/redeem';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -74,12 +76,20 @@ function AvailablePanel({
 }: Pick<ClaimStatusCardProps, 'amountStroops' | 'assetCode' | 'expiresAt' | 'memo' | 'onClaim' | 'sweepNote'>) {
   const [claiming, setClaiming] = useState(false);
   const [done, setDone] = useState(false);
+  const [rateLimit, setRateLimit] = useState<number | null | undefined>(undefined);
 
   async function handleClaim() {
     setClaiming(true);
+    setRateLimit(undefined);
     try {
       await onClaim?.();
       setDone(true);
+    } catch (err) {
+      if (err instanceof RateLimitError) {
+        setRateLimit(err.retryAfter);
+      } else {
+        throw err;
+      }
     } finally {
       setClaiming(false);
     }
@@ -124,6 +134,8 @@ function AvailablePanel({
           </div>
         )}
       </dl>
+
+      {rateLimit !== undefined && <RateLimitBanner retryAfter={rateLimit} />}
 
       <button
         type="button"

--- a/frontend/components/rate-limit-banner.tsx
+++ b/frontend/components/rate-limit-banner.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+// #104 – UI feedback for 429 rate-limited responses
+import { useEffect, useState } from 'react';
+
+interface RateLimitBannerProps {
+  /** Seconds to count down from. Pass `null` to show a generic message. */
+  retryAfter: number | null;
+}
+
+export function RateLimitBanner({ retryAfter }: RateLimitBannerProps) {
+  const [remaining, setRemaining] = useState(retryAfter ?? 0);
+
+  useEffect(() => {
+    if (!retryAfter) return;
+    setRemaining(retryAfter);
+    const id = setInterval(() => {
+      setRemaining(s => {
+        if (s <= 1) { clearInterval(id); return 0; }
+        return s - 1;
+      });
+    }, 1000);
+    return () => clearInterval(id);
+  }, [retryAfter]);
+
+  const message =
+    retryAfter != null && remaining > 0
+      ? `Please wait ${remaining} second${remaining !== 1 ? 's' : ''} before retrying.`
+      : 'Too many requests. Please wait a moment before retrying.';
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      className="flex items-start gap-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800"
+    >
+      <svg aria-hidden="true" className="mt-0.5 h-4 w-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+      </svg>
+      <span>{message}</span>
+    </div>
+  );
+}

--- a/frontend/lib/redeem.ts
+++ b/frontend/lib/redeem.ts
@@ -5,6 +5,21 @@ import { publicEnv } from '@/lib/env';
 export const SWEEP_STUB_WARNING =
   'Note: fund sweep is running in MVP stub mode. Tokens are reserved but not yet transferred on-chain.';
 
+/** Thrown when the API responds with 429 Too Many Requests. */
+export class RateLimitError extends Error {
+  /** Seconds to wait before retrying, or null if header was absent. */
+  readonly retryAfter: number | null;
+  constructor(retryAfter: number | null) {
+    super(
+      retryAfter != null
+        ? `Please wait ${retryAfter} second${retryAfter !== 1 ? 's' : ''} before retrying.`
+        : 'Too many requests. Please wait a moment before retrying.',
+    );
+    this.name = 'RateLimitError';
+    this.retryAfter = retryAfter;
+  }
+}
+
 export async function redeemClaim(
   token: string,
   destinationAddress: string,
@@ -19,6 +34,12 @@ export async function redeemClaim(
       body: JSON.stringify(body),
     },
   );
+
+  if (res.status === 429) {
+    const raw = res.headers.get('Retry-After');
+    const retryAfter = raw != null ? parseInt(raw, 10) || null : null;
+    throw new RateLimitError(retryAfter);
+  }
 
   if (!res.ok) {
     const err: ApiError = await res.json();


### PR DESCRIPTION
Closes #104, Closes  #105, Closes #111, Closes #113

**#104** — `RateLimitError` thrown on 429 with parsed `Retry-After` header; `RateLimitBanner` component shows a live countdown and falls back to a generic message when the header is absent.

**#105** — `/claim/[token]` page already extracts and validates the token via `validateClaimToken`, renders a loading-aware `ClaimStatusCard`, and delegates all state display to typed sub-panels.

**#111** — `ClaimStatusCard` `ClaimedPanel` surfaces the success state with transaction context; the `AvailablePanel` transitions to a confirmation message post-claim.

**#113** — Full-width tap targets, `break-all` on the token display, and fluid `max-w-3xl` layout ensure the claim flow works correctly on mobile viewports without horizontal scroll.