### PR TITLE
[#146] # Experiment: Freighter wallet for sender signing

### DIFF
--- a/docs/experiments/freighter-sender-signing.md
+++ b/docs/experiments/freighter-sender-signing.md
@@ -1,0 +1,42 @@
+# Experiment: Freighter Sender Signing for Account Creation
+
+## Goal
+
+Evaluate a client-side sender-signing path where the browser asks Freighter to sign an unsigned account-creation transaction XDR, instead of relying only on backend signing keys.
+
+## Implemented Flow
+
+1. Sender connects Freighter in the send flow.
+2. On Confirm, frontend attempts `POST /api/accounts/prepare` with the account payload.
+3. If `unsignedTxXdr` is returned, frontend signs via Freighter `signTransaction`.
+4. Frontend submits `POST /api/accounts` with:
+   - the original account-creation payload
+   - `signedTxXdr`
+   - `signerAddress`
+   - `networkPassphrase`
+   - `signingMode: "freighter-client"`
+5. If prepare/sign is unavailable, frontend falls back to existing backend signing path.
+
+## Why Fallback Exists
+
+This is intentionally experimental. Some environments may not yet implement the `prepare` endpoint or may not expose transaction signing capabilities. Fallback keeps the sender flow operational while the experiment rolls out.
+
+## Security Tradeoffs
+
+Pros:
+- Reduces backend custody over sender signing for account creation.
+- Sender private key remains in wallet extension; browser receives only signed XDR.
+- Improves non-custodial posture for funding authorization.
+
+Cons / Risks:
+- Browser-side signing adds wallet/API dependency and extension UX failure modes.
+- Unsigned XDR still originates from backend; integrity checks are required server-side.
+- Fallback path can hide rollout gaps unless monitored.
+
+## Validation Checklist
+
+- Frontend typecheck passes.
+- Frontend tests pass, including wallet signing helper tests.
+- Manual send flow test:
+  - Freighter installed path attempts prepare/sign/submit.
+  - Missing-prepare path falls back and still returns claim URL.

--- a/frontend/components/send-form/steps/confirm-step.tsx
+++ b/frontend/components/send-form/steps/confirm-step.tsx
@@ -4,6 +4,10 @@ import { useState } from 'react';
 import type { SendFormState } from '../index';
 import { useNfc } from '@/hooks/use-nfc';
 import { BridgeletClient, RateLimitError, BridgeletApiError } from '@/lib/api/client';
+import {
+  isFreighterTransactionSigningAvailable,
+  signFreighterTransaction,
+} from '@/lib/wallet';
 
 /**
  * Default claim window for accounts created from the send form.
@@ -36,23 +40,65 @@ export function ConfirmStep({ state, onBack }: ConfirmStepProps) {
   const [claimUrl, setClaimUrl] = useState<string | null>(null);
   const { isSupported, writeUrl, isWriting, error: nfcError } = useNfc();
 
+  function buildCreateAccountPayload() {
+    return {
+      fundingSource: state.publicKey,
+      // No dedicated recovery-address field in the send form yet — funds
+      // return to the sender's own wallet if the claim window expires.
+      recovery_address: state.publicKey,
+      amount: state.amountXlm,
+      asset_code: state.assetCode !== 'XLM' ? state.assetCode : undefined,
+      expiresIn: DEFAULT_EXPIRES_IN_SECONDS,
+      metadata: {
+        recipientEmail: state.recipientEmail,
+        memo: state.memo || undefined,
+      },
+    };
+  }
+
+  function canFallbackToBackendSigning(err: unknown): boolean {
+    if (err instanceof BridgeletApiError && [404, 405, 422, 501].includes(err.statusCode)) {
+      return true;
+    }
+
+    if (!(err instanceof Error)) return false;
+    return (
+      err.message.includes('Missing unsigned transaction XDR') ||
+      err.message.includes('Freighter transaction signing is not available') ||
+      err.message.includes('did not return a signed transaction')
+    );
+  }
+
   async function handleConfirm() {
     setSubmitting(true);
     setError(null);
     try {
-      const account = await client.createAccount({
-        fundingSource: state.publicKey,
-        // No dedicated recovery-address field in the send form yet — funds
-        // return to the sender's own wallet if the claim window expires.
-        recovery_address: state.publicKey,
-        amount: state.amountXlm,
-        asset_code: state.assetCode !== 'XLM' ? state.assetCode : undefined,
-        expiresIn: DEFAULT_EXPIRES_IN_SECONDS,
-        metadata: {
-          recipientEmail: state.recipientEmail,
-          memo: state.memo || undefined,
-        },
-      });
+      const payload = buildCreateAccountPayload();
+
+      let account;
+
+      try {
+        if (isFreighterTransactionSigningAvailable()) {
+          const prepared = await client.prepareAccountTransaction(payload);
+          const signed = await signFreighterTransaction(prepared.unsignedTxXdr);
+          account = await client.createAccount({
+            ...payload,
+            signedTxXdr: signed.signedTxXdr,
+            signerAddress: signed.signerAddress,
+            networkPassphrase: signed.networkPassphrase,
+            signingMode: 'freighter-client',
+          });
+        } else {
+          account = await client.createAccount(payload);
+        }
+      } catch (err) {
+        if (!canFallbackToBackendSigning(err)) {
+          throw err;
+        }
+
+        // Experimental endpoint may not exist in all environments yet.
+        account = await client.createAccount(payload);
+      }
 
       if (!account.claimUrl) {
         throw new Error(

--- a/frontend/lib/bridgelet.ts
+++ b/frontend/lib/bridgelet.ts
@@ -13,6 +13,10 @@ export interface CreateAccountRequest {
   asset_issuer?: string;
   expiresIn: number;
   metadata?: Record<string, unknown>;
+  signedTxXdr?: string;
+  signerAddress?: string;
+  networkPassphrase?: string;
+  signingMode?: 'backend' | 'freighter-client';
 }
 
 export type AccountStatus = 'pending' | 'claimed' | 'expired';

--- a/frontend/lib/create-bridgelet-client.ts
+++ b/frontend/lib/create-bridgelet-client.ts
@@ -21,6 +21,12 @@ export interface BridgeletClientOptions {
   maxDelayMs?: number;
 }
 
+export interface PreparedAccountTransaction {
+  unsignedTxXdr: string;
+  networkPassphrase?: string;
+  expiresAt?: string;
+}
+
 /** Thrown when the API responds with 429 Too Many Requests. */
 export class RateLimitError extends Error {
   readonly retryAfter: number | null;
@@ -141,6 +147,13 @@ export class BridgeletClient {
 
   createAccount(data: CreateAccountRequest): Promise<AccountResponse> {
     return this.request<AccountResponse>(`${this.internalBaseUrl}/api/accounts`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  prepareAccountTransaction(data: CreateAccountRequest): Promise<PreparedAccountTransaction> {
+    return this.request<PreparedAccountTransaction>(`${this.internalBaseUrl}/api/accounts/prepare`, {
       method: 'POST',
       body: JSON.stringify(data),
     });

--- a/frontend/lib/wallet.test.ts
+++ b/frontend/lib/wallet.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@stellar/freighter-api', () => ({
+  default: {
+    isConnected: vi.fn(),
+    requestAccess: vi.fn(),
+    getAddress: vi.fn(),
+    signTransaction: vi.fn(),
+  },
+}));
+
+import freighter from '@stellar/freighter-api';
+import {
+  isFreighterTransactionSigningAvailable,
+  signFreighterTransaction,
+} from '@/lib/wallet';
+
+describe('wallet signing helpers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_CRYPTO_NETWORK = 'stellar-testnet';
+  });
+
+  it('detects freighter transaction signing availability', () => {
+    expect(isFreighterTransactionSigningAvailable()).toBe(true);
+  });
+
+  it('signs an unsigned xdr and returns signer metadata', async () => {
+    vi.mocked((freighter as any).signTransaction).mockResolvedValue({
+      signedTxXdr: 'AAAA_SIGNED_XDR',
+    });
+    vi.mocked((freighter as any).getAddress).mockResolvedValue({
+      address: 'G' + 'A'.repeat(55),
+    });
+
+    const result = await signFreighterTransaction('AAAA_UNSIGNED_XDR');
+
+    expect((freighter as any).signTransaction).toHaveBeenCalledWith('AAAA_UNSIGNED_XDR', {
+      networkPassphrase: 'Test SDF Network ; September 2015',
+    });
+    expect(result).toEqual({
+      signedTxXdr: 'AAAA_SIGNED_XDR',
+      signerAddress: 'G' + 'A'.repeat(55),
+      networkPassphrase: 'Test SDF Network ; September 2015',
+    });
+  });
+
+  it('supports signedTxXDR from freighter response', async () => {
+    vi.mocked((freighter as any).signTransaction).mockResolvedValue({
+      signedTxXDR: 'AAAA_ALT_SIGNED_XDR',
+    });
+    vi.mocked((freighter as any).getAddress).mockResolvedValue({
+      address: 'G' + 'B'.repeat(55),
+    });
+
+    const result = await signFreighterTransaction('AAAA_UNSIGNED_XDR');
+    expect(result.signedTxXdr).toBe('AAAA_ALT_SIGNED_XDR');
+  });
+
+  it('throws for missing unsigned xdr', async () => {
+    await expect(signFreighterTransaction('   ')).rejects.toThrow(
+      'Missing unsigned transaction XDR from server.',
+    );
+  });
+
+  it('throws when freighter response does not include signed xdr', async () => {
+    vi.mocked((freighter as any).signTransaction).mockResolvedValue({});
+
+    await expect(signFreighterTransaction('AAAA_UNSIGNED_XDR')).rejects.toThrow(
+      'Freighter did not return a signed transaction.',
+    );
+  });
+});

--- a/frontend/lib/wallet.ts
+++ b/frontend/lib/wallet.ts
@@ -7,7 +7,23 @@ export interface ConnectedWallet {
   type: WalletType;
 }
 
+export interface SignedFreighterTransaction {
+  signedTxXdr: string;
+  signerAddress: string;
+  networkPassphrase: string;
+}
+
+const NETWORK_PASSPHRASES: Record<string, string> = {
+  'stellar-testnet': 'Test SDF Network ; September 2015',
+  'stellar-mainnet': 'Public Global Stellar Network ; September 2015',
+};
+
 const STORAGE_KEY = 'bridgelet_wallet';
+
+function resolveNetworkPassphrase(): string {
+  const network = process.env['NEXT_PUBLIC_CRYPTO_NETWORK'] ?? 'stellar-testnet';
+  return NETWORK_PASSPHRASES[network] ?? 'Test SDF Network ; September 2015';
+}
 
 // Save wallet to localStorage so it survives page refreshes
 export function persistWallet(wallet: ConnectedWallet): void {
@@ -47,6 +63,54 @@ export async function connectFreighter(): Promise<ConnectedWallet> {
   }
 
   return { publicKey: address, type: 'freighter' };
+}
+
+export function isFreighterTransactionSigningAvailable(): boolean {
+  const maybeSigner = (freighter as unknown as { signTransaction?: unknown }).signTransaction;
+  return typeof maybeSigner === 'function';
+}
+
+export async function signFreighterTransaction(
+  unsignedTxXdr: string,
+): Promise<SignedFreighterTransaction> {
+  if (!unsignedTxXdr.trim()) {
+    throw new Error('Missing unsigned transaction XDR from server.');
+  }
+
+  if (!isFreighterTransactionSigningAvailable()) {
+    throw new Error('Freighter transaction signing is not available in this environment.');
+  }
+
+  const networkPassphrase = resolveNetworkPassphrase();
+  const signResult = await (
+    freighter as unknown as {
+      signTransaction: (
+        xdr: string,
+        options: { networkPassphrase: string },
+      ) => Promise<Record<string, unknown>>;
+    }
+  ).signTransaction(unsignedTxXdr, { networkPassphrase });
+
+  const signedTxXdr =
+    (typeof signResult['signedTxXdr'] === 'string' && signResult['signedTxXdr']) ||
+    (typeof signResult['signedTxXDR'] === 'string' && signResult['signedTxXDR']) ||
+    (typeof signResult['xdr'] === 'string' && signResult['xdr']) ||
+    '';
+
+  if (!signedTxXdr) {
+    throw new Error('Freighter did not return a signed transaction.');
+  }
+
+  const { address } = await freighter.getAddress();
+  if (!address) {
+    throw new Error('Freighter did not return a signer address.');
+  }
+
+  return {
+    signedTxXdr,
+    signerAddress: address,
+    networkPassphrase,
+  };
 }
 
 // LOBSTR is mobile-only, so on desktop we deeplink and poll for a result


### PR DESCRIPTION
## Summary\n- add an experimental Freighter sender-signing path for account creation in the send confirm flow\n- add wallet signing helpers and request contract fields for signed transaction submission\n- add sender-signing experiment documentation and wallet signing unit tests\n\n## Validation\n- npm.cmd run typecheck -- --pretty false\n- npm.cmd test\n- npm.cmd run build\n\nCloses #146