### PR TITLE
feat: add bottom CTA banner 'Integrate Bridgelet Today' to homepage

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,12 +1,14 @@
 import Link from 'next/link';
 import { PageShell } from '@/components/page-shell';
 import { HowItWorks } from '@/components/how-it-works';
+import { CTABanner } from '@/components/cta-banner';
 
 export default function HomePage() {
   return (
     <PageShell
       title="Bridgelet Payment Flows"
       description="Reference placeholder UI for sender and recipient claim experiences."
+      footer={<CTABanner />}
     >
       <div className="space-y-8">
         <HowItWorks intervalMs={3500} />

--- a/frontend/components/cta-banner.stories.tsx
+++ b/frontend/components/cta-banner.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { CTABanner } from './cta-banner';
+
+const meta: Meta<typeof CTABanner> = {
+  title: 'Components/CTABanner',
+  component: CTABanner,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof CTABanner>;
+
+export const Default: Story = {};

--- a/frontend/components/cta-banner.test.tsx
+++ b/frontend/components/cta-banner.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { CTABanner } from './cta-banner';
+
+describe('CTABanner', () => {
+  it('renders the headline', () => {
+    render(<CTABanner />);
+    expect(screen.getByRole('heading', { name: /integrate bridgelet today/i })).toBeInTheDocument();
+  });
+
+  it('renders a "View on GitHub" link pointing to the repo', () => {
+    render(<CTABanner />);
+    const link = screen.getByRole('link', { name: /view on github/i });
+    expect(link).toHaveAttribute('href', 'https://github.com/bridgelet-org/bridgelet');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('renders a "Read the Docs" link', () => {
+    render(<CTABanner />);
+    const link = screen.getByRole('link', { name: /read the docs/i });
+    expect(link).toHaveAttribute('href', '/docs');
+  });
+
+  it('has an accessible section label', () => {
+    render(<CTABanner />);
+    expect(screen.getByRole('region', { name: /integrate bridgelet today/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/components/cta-banner.tsx
+++ b/frontend/components/cta-banner.tsx
@@ -1,0 +1,67 @@
+import Link from 'next/link';
+
+/**
+ * Full-width CTA banner displayed at the bottom of the homepage.
+ * Issue #181 — "Integrate Bridgelet Today"
+ */
+export function CTABanner() {
+  return (
+    <section
+      aria-labelledby="cta-heading"
+      className="w-full bg-slate-900 px-6 py-16 text-center"
+    >
+      <div className="mx-auto max-w-2xl space-y-6">
+        <h2
+          id="cta-heading"
+          className="text-3xl font-bold tracking-tight text-white sm:text-4xl"
+        >
+          Integrate Bridgelet Today
+        </h2>
+        <p className="text-base text-slate-300">
+          Start sending payments to anyone — even recipients without a crypto wallet. Open-source,
+          composable, and built for the Stellar ecosystem.
+        </p>
+        <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
+          <a
+            href="https://github.com/bridgelet-org/bridgelet"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-lg bg-white px-6 py-3 text-sm font-semibold text-slate-900 transition hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+          >
+            {/* GitHub icon */}
+            <svg
+              aria-hidden="true"
+              className="h-5 w-5"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+            >
+              <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844a9.59 9.59 0 012.504.337c1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
+            </svg>
+            View on GitHub
+          </a>
+          <Link
+            href="/docs"
+            className="inline-flex items-center gap-2 rounded-lg border border-slate-600 px-6 py-3 text-sm font-semibold text-white transition hover:border-slate-400 hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+          >
+            {/* Book icon */}
+            <svg
+              aria-hidden="true"
+              className="h-5 w-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
+              />
+            </svg>
+            Read the Docs
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/components/page-shell.tsx
+++ b/frontend/components/page-shell.tsx
@@ -6,9 +6,11 @@ type PageShellProps = {
   title: string;
   description: string;
   children?: ReactNode;
+  /** Optional full-width content rendered below the main section (e.g. a CTA banner). */
+  footer?: ReactNode;
 };
 
-export function PageShell({ title, description, children }: PageShellProps) {
+export function PageShell({ title, description, children, footer }: PageShellProps) {
   return (
     <div className="flex min-h-screen flex-col">
       <nav className="border-b border-slate-200 bg-white px-6 py-3">
@@ -26,6 +28,7 @@ export function PageShell({ title, description, children }: PageShellProps) {
           {children}
         </section>
       </main>
+      {footer}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Adds a full-width CTA banner at the bottom of the homepage as specified in issue #181.

## Changes

- **`frontend/components/cta-banner.tsx`** (new) — Full-width banner with dark (`bg-slate-900`) background, headline, and two action buttons:
  - **View on GitHub** — external link to `https://github.com/bridgelet-org/bridgelet` (opens in new tab, `rel=noopener noreferrer`)
  - **Read the Docs** — internal link to `/docs`
- **`frontend/components/page-shell.tsx`** — Added optional `footer?: ReactNode` prop rendered below `<main>` for full-width content
- **`frontend/app/page.tsx`** — Wired `<CTABanner />` as the `footer` prop on the homepage `PageShell`
- **`frontend/components/cta-banner.test.tsx`** (new) — 4 unit tests covering headline, GitHub link, docs link, and accessible section label
- **`frontend/components/cta-banner.stories.tsx`** (new) — Storybook story with `layout: fullscreen`

## Testing

All 38 existing tests pass + 4 new tests (42 total). TypeScript clean.

Closes #181