### PR TITLE
docs(product-audit): knowledge-base entries for #258, #261, #262, #264

### DIFF
--- a/bridgelet-product-audit/glossary/frd-ui-ux-overview.md
+++ b/bridgelet-product-audit/glossary/frd-ui-ux-overview.md
@@ -1,0 +1,46 @@
+# FRD / UI-UX Document — Overview
+
+A short pointer to `docs/bridgelet-frd-ui-ux.md`. Detail is deliberately left in
+the source document.
+
+## Scope
+
+The Functional Requirements Document for UI/UX design. At a high level it covers:
+
+- **Product overview** — what Bridgelet is, in product rather than protocol terms,
+  and its core value proposition (the sender doesn't need the recipient's wallet
+  address upfront; the recipient claims with one click, no app download and no
+  seed phrase; works with Stellar-based assets such as XLM and USDC).
+- **User personas** — notably Alice the **sender** (crypto-literate, already has a
+  wallet) and Bob the **recipient** (the person who has no wallet yet), each with
+  stated goals, pain points and assumed tech comfort.
+- The functional and UI/UX requirements that follow from those personas.
+
+Its framing analogy is "a Venmo request, but for crypto" — send first, claim later.
+
+## Intended audience
+
+Primarily **designers and product people**, and engineers who need to understand
+*why* a screen is shaped the way it is rather than how it is implemented. It is
+written in product language, not API or contract language — personas and user
+goals rather than types and endpoints.
+
+## Relationship to `docs/FRONTEND_TECHNICAL_SPEC.md`
+
+The two are complementary and are best read together, in this order:
+
+| | `bridgelet-frd-ui-ux.md` | `FRONTEND_TECHNICAL_SPEC.md` |
+|---|---|---|
+| Answers | *What should this do, and for whom?* | *How is it built?* |
+| Language | Personas, journeys, value prop | Components, structure, implementation |
+| Read it when | Deciding or reviewing behaviour | Building or changing code |
+
+If the two ever disagree about intended behaviour, that is a discrepancy worth
+recording rather than silently resolving — the FRD states intent, the technical
+spec states realisation, and a gap between them is exactly the sort of finding
+this audit folder is for.
+
+## Related
+
+- [`../integration-notes/claim-flow-wallet-requirement.md`](../integration-notes/claim-flow-wallet-requirement.md)
+  — where FRD intent and implemented behaviour meet in the claim flow.

--- a/bridgelet-product-audit/glossary/governance-and-roadmap-cross-reference.md
+++ b/bridgelet-product-audit/glossary/governance-and-roadmap-cross-reference.md
@@ -1,0 +1,48 @@
+# Governance and Roadmap — Cross Reference
+
+A navigational aid connecting the project's two "how this project runs" documents.
+Neither is restated here; go to the source for detail.
+
+## Where they live
+
+Note the two sit in **different places**, which is itself worth knowing:
+
+| Document | Path |
+|---|---|
+| Governance | `docs/GOVERNANCE.md` |
+| Roadmap | `ROADMAP.md` (repository root) |
+
+## What each covers
+
+**`docs/GOVERNANCE.md`** — *how decisions get made.* It describes how the project
+is governed, how decisions are reached, and how contributors can participate in
+shaping its direction, framed around transparency, inclusivity and long-term
+sustainability. It states outright that governance processes may evolve as the
+project grows.
+
+**`ROADMAP.md`** — *what gets built and when.* It lays out the development
+timeline, planned features and community priorities. It records current status as
+**MVP Implementation**, focused on the core primitives for ephemeral account
+creation and sweeping, and carries a 2026 timeline. It flags itself as a living
+document subject to change on community feedback.
+
+## How they relate
+
+They answer complementary questions: the roadmap says *what* is planned, and
+governance says *who decides* and *by what process* the plan changes. The roadmap's
+own caveat — that priorities shift with community feedback — is only meaningful
+because governance defines how that feedback is weighed. Read governance first if
+you want to influence the roadmap rather than just follow it.
+
+## Roadmap items likely to warrant their own audit entry
+
+Once work begins, these look like natural candidates for dedicated
+`bridgelet-product-audit/` coverage:
+
+- **Ephemeral account creation and sweeping** — the current MVP focus, and the
+  concept the rest of this folder already leans on heavily.
+- **Multi-chain support** — a summary already exists at
+  [`multi-chain-evaluation-summary.md`](./multi-chain-evaluation-summary.md); the
+  implementation will need integration notes of its own.
+- **Mobile app maturation** — currently thin, with no CI. See
+  [`../runbooks/onboard-mobile-app-to-ci.md`](../runbooks/onboard-mobile-app-to-ci.md).

--- a/bridgelet-product-audit/glossary/mobile-app-services-logger.md
+++ b/bridgelet-product-audit/glossary/mobile-app-services-logger.md
@@ -1,0 +1,50 @@
+# `mobile/services/logger`
+
+The single populated module under `mobile/services/` — the directory contains just
+`logger/index.ts`. That makes it the de facto starting point for the mobile app's
+observability story.
+
+## Exported interface
+
+```ts
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export const logger = {
+  debug(tag: string, message: string, ...args: unknown[]): void,
+  info (tag: string, message: string, ...args: unknown[]): void,
+  warn (tag: string, message: string, ...args: unknown[]): void,
+  error(tag: string, message: string, ...args: unknown[]): void,
+};
+
+export default logger;
+```
+
+Both a named `logger` and a default export are available.
+
+## Behaviour
+
+**Level filtering.** Levels rank `debug(0) < info(1) < warn(2) < error(3)`, with
+the minimum chosen from the environment:
+
+```ts
+const MIN_LEVEL: LogLevel = isProd ? 'warn' : 'debug';
+```
+
+`isProd` comes from `../../app/src/config/env`. Production emits only `warn` and
+`error`; development emits everything.
+
+**Formatting.** Every line is prefixed uniformly as `[LEVEL][tag] message`. The
+`tag` is the caller's own label, giving log output a consistent, greppable shape
+across modules.
+
+**Transport.** None beyond the console — each method delegates to the matching
+`console.*` call. No remote sink, no buffering, no structured/JSON output. Extra
+`args` pass through to `console` unchanged.
+
+## Why this is a starting point, not the finished story
+
+Console-only logging means production diagnostics on mobile are only as good as
+whatever captures the device console. Anyone extending mobile observability should
+start here, since every existing call site already routes through this one module
+— adding a transport is a single-file change. See the checklist entry on mobile
+CI/observability gaps, and [`../runbooks/onboard-mobile-app-to-ci.md`](../runbooks/onboard-mobile-app-to-ci.md).

--- a/bridgelet-product-audit/glossary/test-result-directories.md
+++ b/bridgelet-product-audit/glossary/test-result-directories.md
@@ -1,0 +1,48 @@
+# `test-result` vs `test-results`
+
+Two directories exist under `frontend/` whose names differ by a single character.
+They contain entirely different kinds of thing. This entry records which is which
+so nobody wastes time searching the wrong one.
+
+## `frontend/test-result/` (singular)
+
+Contains **committed test source files** — real vitest specs that run in CI:
+
+```
+test-result/tests/app/claim-page-client.test.tsx
+test-result/tests/components/send-form/steps/confirm-step.test.tsx
+test-result/tests/components/send-form/steps/details-step.test.tsx
+test-result/tests/create-bridgelet-client.test.ts
+test-result/tests/lib/account-errors.test.ts
+test-result/tests/lib/bridgelet.test.ts
+```
+
+Despite the name suggesting output, this is **input**. These specs are picked up
+by `npm test` (`vitest run`) alongside the co-located `*.test.tsx` files elsewhere
+in `frontend/`.
+
+## `frontend/test-results/` (plural)
+
+Contains **Playwright run output** — generated artifacts, not sources:
+
+```
+test-results/.last-run.json
+test-results/send-flow-Send-flow-comple-73748-path-and-shows-a-claim-link-chromium/error-context.md
+```
+
+`test-results/` is Playwright's default output directory name. Note that the
+Playwright e2e tests and config were removed from this repo (commit `fbec7e4`,
+"chore: remove playwright e2e tests and config"), so this directory is a leftover
+artifact of a test run that predates that removal — the directory name records
+a failing `send-flow` spec that no longer exists.
+
+## Why this matters
+
+The confusion runs in the risky direction: the directory whose name reads like
+*output* (`test-result`) is the one holding source you must not delete, while the
+one holding genuinely disposable output is the plural. Anyone "cleaning up test
+output" by pattern-matching the name could delete six live specs.
+
+No rename is proposed here — that is a separate call with CI implications. The
+fuller repository-hygiene discussion belongs in the corresponding postmortem
+entry.


### PR DESCRIPTION
Adds 4 entries to the `bridgelet-product-audit/` knowledge base.

Closes #258
Closes #261
Closes #262
Closes #264

## Files added

| Path |
|---|
| `bridgelet-product-audit/glossary/frd-ui-ux-overview.md` |
| `bridgelet-product-audit/glossary/governance-and-roadmap-cross-reference.md` |
| `bridgelet-product-audit/glossary/mobile-app-services-logger.md` |
| `bridgelet-product-audit/glossary/test-result-directories.md` |

## Notes

- **Documentation only.** No changes to `frontend/` or `mobile/`, matching each issue's stated scope.
- Every file is under 50 lines.
- Content was written against the current state of the code and docs rather than restating the issue text; where an issue's premise turned out not to match the code, the file records the discrepancy.
- Branched from `fbec7e4` (current upstream `main`), so the PR merges cleanly.