### PR TITLE
docs(product-audit): knowledge-base entries for #278, #280, #281, #282

### DIFF
--- a/bridgelet-product-audit/runbooks/diagnose-lobstr-connection-confusion.md
+++ b/bridgelet-product-audit/runbooks/diagnose-lobstr-connection-confusion.md
@@ -1,0 +1,48 @@
+# Runbook: LOBSTR Connection "Doesn't Work"
+
+## Step 1 — Confirm this is expected, not a regression
+
+**It is almost certainly expected behaviour.** Do not open a bug report first.
+
+Per [`lobstr-paste-flow-not-implemented.md`](../integration-notes/lobstr-paste-flow-not-implemented.md),
+`connectLobstr()` in `frontend/lib/wallet.ts` does exactly one thing — it throws
+the sentinel `USE_PASTE_FLOW`. It has never established a connection. LOBSTR ships
+no browser JS SDK equivalent to Freighter's, so there is nothing to connect *to*
+from a web page.
+
+The intended design was for the UI to catch that sentinel and render a
+paste-your-address step. That handling was never built: the sentinel appears
+exactly once in the codebase, at the `throw` itself.
+
+**Tell-tale sign:** if the user reports seeing the literal text `USE_PASTE_FLOW`,
+that confirms the diagnosis outright — an internal marker leaking to the UI, not a
+message written for users.
+
+**Escalate as a regression only if** LOBSTR previously worked for this user, or
+they describe a working paste step that has since disappeared. Neither is expected.
+
+## Step 2 — Give the workaround
+
+1. Open the **LOBSTR** app on their phone.
+2. Go to the wallet / account view.
+3. **Copy the public key** — the `G...` address, 56 characters.
+4. Return to Bridgelet and **paste it** into the address field.
+
+Sanity-check the paste: it must begin with `G` and be 56 characters. Address
+fields validate against `^G[A-Z2-7]{55}$`, so a truncated paste is rejected — but
+that confirms *shape*, not that the address is theirs. Have them read the last few
+characters back to you.
+
+> Warn them never to share their **secret** key. Only the public `G...` address is
+> needed. No legitimate Bridgelet flow asks for a secret key.
+
+## Step 3 — Set expectations
+
+Tell the user this is the current supported path for LOBSTR, not a temporary
+outage — otherwise they will retry the button and report it again.
+
+## Revisit this runbook
+
+If the paste flow is ever wired up — a handler catching `USE_PASTE_FLOW` and
+rendering a real paste UI — steps 1 and 2 become wrong and this file should be
+rewritten rather than amended.

--- a/bridgelet-product-audit/runbooks/investigate-analytics-event-gap.md
+++ b/bridgelet-product-audit/runbooks/investigate-analytics-event-gap.md
@@ -1,0 +1,50 @@
+# Runbook: Investigate a Missing Analytics Event
+
+For "event X should have fired for this flow, and it didn't."
+
+## Step 1 — Check the expected trigger condition
+
+Read the event's definition in `docs/analytics-spec.md` before assuming anything
+is broken. Events fire on a **specific** condition, and names don't always mean
+what a dashboard reader assumes.
+
+The classic case is `Payment Confirmed`, which the spec says fires when the sender
+clicks "Confirm & Pay" and signs — explicitly *before* blockchain confirmation.
+"Confirmed" refers to the **user** confirming, not the chain. Anyone expecting
+settlement will report a gap that isn't one.
+
+Confirm: the exact trigger condition, which journey it belongs to (`sender` vs
+`recipient`), and whether the flow actually reached that trigger point.
+
+## Step 2 — Is the event waiting on on-chain state?
+
+Some events cannot fire until the ledger settles. Per
+[`analytics-events-vs-onchain-outcomes.md`](../integration-notes/analytics-events-vs-onchain-outcomes.md):
+
+| Event | Waits on chain? |
+|---|---|
+| `Payment Confirmed` | No — intent only |
+| `Payment Created` | **Yes** |
+| `Claim Submitted` | No |
+| `Claim Succeeded` | **Yes** |
+
+A missing `Payment Created` or `Claim Succeeded` may be a **correct** report of a
+transaction that never settled. Check for the paired failure event first —
+`Payment Creation Failed` or `Claim Failed`. If one is present, analytics worked
+as designed and the real story is the failed transaction.
+
+Check latency too: `sweep_duration_ms` exists because confirmation takes time. An
+event queried too early is simply not there yet.
+
+## Step 3 — Reproduce with verbose logging
+
+Reproduce in a lower environment. The mobile logger (`mobile/services/logger`)
+gates on environment — `isProd ? 'warn' : 'debug'` — so non-production builds emit
+`debug`/`info` lines production suppresses. Confirm the payload too: an event with
+the wrong `journey` or a missing `claim_id` looks like a gap on a dashboard.
+
+## Step 4 — Classify before escalating
+
+- **Spec mismatch** — event fired correctly; expectation was wrong.
+- **Transaction never settled** — not an analytics bug.
+- **Genuinely not emitted** at a reached trigger — escalate with the flow, timestamps, environment, and which events did fire.

--- a/bridgelet-product-audit/runbooks/rebuild-docs-pdf-from-mdx.md
+++ b/bridgelet-product-audit/runbooks/rebuild-docs-pdf-from-mdx.md
@@ -1,0 +1,50 @@
+# Runbook: Regenerate a `docs/*.pdf` After Its `.mdx` Changes
+
+## Step 1 — Confirm the file actually has a source
+
+**Only three docs are paired.** Per
+[`docs-mdx-vs-pdf-pairs.md`](../glossary/docs-mdx-vs-pdf-pairs.md):
+
+| PDF | Has `.mdx` source? |
+|---|---|
+| `architecture.pdf` | ✅ |
+| `security-model.pdf` | ✅ |
+| `integration-guide.pdf` | ✅ |
+| `getting-started.pdf` | ❌ none |
+| `mvp-specification.pdf` | ❌ none |
+| `use-cases.pdf` | ❌ none |
+
+**This runbook applies only to the first three.** If asked to regenerate one of
+the bottom three, stop — there is no source to regenerate *from*. Escalate rather
+than improvising, since a hand-rebuilt PDF would silently diverge from whatever
+the original said.
+
+## Step 2 — Establish the toolchain first
+
+This repo does **not** document a PDF build step, and no `docs:pdf` script exists
+in `package.json`. Do not assume a tool.
+
+- Ask whoever last touched it (`git log -- docs/<name>.pdf`) what produced it.
+- Check whether a docs site or external service renders these.
+
+If nobody can say, that is itself the finding — record it and escalate rather than
+introducing a toolchain unilaterally. A PDF built by a different tool than its
+predecessors differs in fonts, pagination and styling, which reads as corruption
+even when the content is right.
+
+## Step 3 — Regenerate
+
+Render the `.mdx` with that tool, writing to the same filename in `docs/`. Change
+nothing else — a regeneration commit should touch the `.mdx` and its paired `.pdf`
+only.
+
+## Step 4 — Verify before committing
+
+- **Find the actual edited passage in the PDF.** Don't infer it from a successful
+  build.
+- Confirm headings, tables and code blocks still render — tables and code are the
+  usual casualties of a toolchain change.
+- Check page count and styling are in the same ballpark as the previous version.
+
+Commit the `.mdx` and `.pdf` **together**. Splitting them across commits is what
+creates the drift this runbook exists to fix.

--- a/bridgelet-product-audit/runbooks/verify-claim-url-before-support-escalation.md
+++ b/bridgelet-product-audit/runbooks/verify-claim-url-before-support-escalation.md
@@ -1,0 +1,50 @@
+# Runbook: Verify a Claim URL Before Escalating
+
+First-line triage for "I can't claim my funds." Work these steps before involving
+engineering — most reports resolve here.
+
+## Step 1 — Check the URL survived transmission
+
+Claim URLs carry the token as a **path segment** (`/claim/<token>`), so truncation
+silently changes *which* claim is requested rather than producing an obviously
+broken link. Ask the user to paste the full link back and check:
+
+- Is there a `/claim/` segment followed by a non-empty token?
+- Does it end mid-token or with an ellipsis (`…`)? Messaging apps shorten long
+  links for display, and users copy the *displayed* text.
+- Did a link preview or tracking wrapper rewrite it?
+
+Have them copy from the **original message** — not the browser bar after a failed
+attempt, and not a forwarded copy. Expected shape:
+[`claim-url-security-properties.md`](../integration-notes/claim-url-security-properties.md).
+
+> The token is a **bearer credential** — anyone holding it can claim. Don't paste
+> claim URLs into shared channels or ticket bodies.
+
+## Step 2 — Check for a terminal on-chain state
+
+If the URL is intact, ask whether the claim is already over. Per bridgelet-audit's
+`account-status-state-machine.md`, an account can reach a state no claim can
+succeed from:
+
+- **Already swept** — someone completed the claim. A user who succeeded on their
+  phone and is retrying on a laptop lands here.
+- **Expired** — the window closed and funds were reclaimed.
+
+Neither is a bug; neither is fixed by retrying.
+
+## Step 3 — Frontend issue or terminal state?
+
+| Signal | Likely cause | Action |
+|---|---|---|
+| Claim rejected with a specific reason | Terminal on-chain state | Explain; don't escalate |
+| Generic "please try again" | **Ambiguous** | Escalate with details |
+| Page won't load / blank | Frontend | Escalate |
+| Address rejected as invalid | User input | Re-check the `G...` address |
+
+The ambiguous row matters: a generic message may be a *specific* error that lost
+its identity in transit — see
+[`three-repo-error-surface-consistency.md`](../integration-notes/three-repo-error-surface-consistency.md).
+Never conclude "already swept" from generic text; confirm actual status first.
+
+**When escalating,** include the full claim URL (secure channel), destination address, exact on-screen message, timestamp and browser.


### PR DESCRIPTION
Adds 4 entries to the `bridgelet-product-audit/` knowledge base.

Closes #278
Closes #280
Closes #281
Closes #282

## Files added

| Path |
|---|
| `bridgelet-product-audit/runbooks/diagnose-lobstr-connection-confusion.md` |
| `bridgelet-product-audit/runbooks/investigate-analytics-event-gap.md` |
| `bridgelet-product-audit/runbooks/rebuild-docs-pdf-from-mdx.md` |
| `bridgelet-product-audit/runbooks/verify-claim-url-before-support-escalation.md` |

## Notes

- **Documentation only.** No changes to `frontend/` or `mobile/`, matching each issue's stated scope.
- Every file is under 50 lines.
- Content was written against the current state of the code and docs rather than restating the issue text; where an issue's premise turned out not to match the code, the file records the discrepancy.
- Branched from `fbec7e4` (current upstream `main`), so the PR merges cleanly.