### PR TITLE
docs(product-audit): knowledge-base entries for #260, #263, #273, #277

### DIFF
--- a/bridgelet-product-audit/glossary/analytics-spec-overview.md
+++ b/bridgelet-product-audit/glossary/analytics-spec-overview.md
@@ -1,0 +1,48 @@
+# Analytics Spec — Overview
+
+A short orientation to `docs/analytics-spec.md` (Bridgelet Analytics & Product
+Event Tracking Specification), which runs to roughly 28KB. This page is the gist;
+**all detail stays in the source document.**
+
+## Categories it defines
+
+The spec is organised in nine sections:
+
+1. **Overview** — purpose and scope.
+2. **Event naming conventions** — how events are named and why consistently.
+3. **Standard payload structure** — properties every event carries.
+4. **Sender journey events** — the send flow, from intent through settlement.
+5. **Recipient journey events** — opening a claim link through a completed sweep.
+6. **Error & edge case events** — failure paths as first-class events.
+7. **Conversion funnel definitions** — how the events compose into funnels.
+8. **Business metrics & KPI definitions** — the derived measures.
+9. **Implementation notes.**
+
+So it covers three broad kinds of thing: **event definitions** (sections 4–6),
+**structural conventions** (2–3), and **derived measurement** (7–8).
+
+## Two things worth knowing before reading
+
+**Journeys are separated.** Sender and recipient events are defined apart and
+tagged with a `journey` property (`"sender"` / `"recipient"`), reflecting that the
+two are usually different people on different devices.
+
+**Failures are events, not absences.** Section 6 gives errors their own events, so
+a failed payment is something you can *count* rather than infer from a missing
+success.
+
+## The one trap
+
+Do not read event names as settlement status. `Payment Confirmed` fires when the
+**user** confirms and signs, explicitly before blockchain confirmation;
+`Payment Created` is the on-chain success. The spec is clear about this, but the
+names invite misreading, and the distinction is load-bearing in the funnel — the
+gap between those two steps is the on-chain failure rate.
+
+Whether each event reflects confirmed on-chain state or optimistic client state is
+worked through in
+[`../integration-notes/analytics-events-vs-onchain-outcomes.md`](../integration-notes/analytics-events-vs-onchain-outcomes.md).
+
+**For any actual implementation work, read the spec itself** — event names,
+payload fields and trigger conditions are precise there and deliberately not
+duplicated here, so this page cannot drift into contradicting it.

--- a/bridgelet-product-audit/glossary/branch-protection-reference.md
+++ b/bridgelet-product-audit/glossary/branch-protection-reference.md
@@ -1,0 +1,49 @@
+# Branch Protection — Quick Reference
+
+A summary of `.github/BRANCH_PROTECTION.md`.
+
+> **The canonical source is `.github/BRANCH_PROTECTION.md` itself.** This is a
+> pointer, not a replacement. Where the two differ, that file wins.
+
+## What it documents
+
+**Protected branch:** `main`.
+
+**Status checks**
+- Required status checks must pass before merging — enabled.
+- Branches must be up to date with `main` before merging — enabled.
+- Failed CI checks block merges.
+
+**Pull request requirements**
+- A pull request is required before merging.
+- At least **1 reviewer** approval.
+- Self-approval disabled (recommended).
+- Stale approvals dismissed when new commits are pushed.
+- Conversation resolution required before merging.
+
+**Tests and coverage**
+- Tests required for merge *where tests exist*.
+- Coverage thresholds **not** enforced yet.
+
+It also lists the local commands to run before pushing, and mentions optional
+Husky pre-commit hooks.
+
+## One discrepancy worth knowing
+
+The listed local commands include `npm run type-check`.
+
+That name is correct for **`mobile/`**, whose `package.json` defines `type-check`.
+It is **not** correct for `frontend/`, which defines `typecheck` (no hyphen).
+Running `npm run type-check` from `frontend/` fails with a missing script rather
+than type-checking anything.
+
+Contributors in `frontend/` should run `npm run typecheck`. This is a
+documentation inconsistency, not a CI problem — `frontend-ci.yml` detects and
+calls the correct name itself.
+
+## Read alongside
+
+`CONTRIBUTING.md` covers process expectations — how to propose changes, branch and
+open a PR. Branch protection is the *enforcement* of those expectations. Read
+both: following CONTRIBUTING without meeting branch protection means an
+unmergeable PR; the reverse means a mergeable PR that skipped the agreed process.

--- a/bridgelet-product-audit/integration-notes/sender-auth-model-doc-accuracy.md
+++ b/bridgelet-product-audit/integration-notes/sender-auth-model-doc-accuracy.md
@@ -1,0 +1,50 @@
+# `sender-auth-model.md` — Accuracy Check
+
+A point-in-time verification of `docs/sender-auth-model.md` against
+`frontend/lib/wallet.ts` and `frontend/components/wallet-connect.tsx`.
+
+## "How It Works"
+
+| # | Claim | Holds? |
+|---|---|---|
+| 1 | `/send` renders a `WalletConnect` component | ✅ exists at the stated path |
+| 2 | User clicks connect; Freighter popup opens | ✅ `requestAccess()` opens it |
+| 3 | On approval the public key is returned | ✅ via `getAddress()`; throws if absent |
+| 4 | "The Bridgelet SDK signs the transaction with the connected key" | ⚠️ **Ambiguous** |
+
+Claim 4 needs rewording. It reads either as *the SDK signs using a key it holds*
+or *the SDK triggers signing by the connected wallet*. The code supports only the
+second — `signFreighterTransaction()` sends XDR to the extension and reads back a
+signature, so the secret never leaves Freighter. Since Bridgelet genuinely holds a
+funding key elsewhere, loose phrasing risks misdescribing the trust model. See
+[`wallet-signing-to-sdk-handoff.md`](./wallet-signing-to-sdk-handoff.md).
+
+## "Security Notes"
+
+| Claim | Holds? |
+|---|---|
+| No session token or JWT; ownership proven at signing time | ✅ none found |
+| **LOBSTR paste fallback "already wired in `lib/wallet.ts`"** | ❌ **primary finding** |
+| Option A (env API key) viable for backend integrations | ✅ deferred — see [`org-integration-api-key-model.md`](../glossary/org-integration-api-key-model.md) |
+
+## Primary finding: the LOBSTR claim is not accurate
+
+`connectLobstr()` implements no paste fallback. Its entire body throws the
+sentinel `USE_PASTE_FLOW`, intended for a UI handler that was never built — the
+sentinel appears exactly once in the repository, at the `throw`. The function also
+has no callers.
+
+"Already wired in `lib/wallet.ts`" misleads in a specific way: the *function* is in
+that file, but what it contains is a request for a paste flow, not one. A reader
+planning around working LOBSTR support would be wrong. Detail in
+[`lobstr-paste-flow-not-implemented.md`](./lobstr-paste-flow-not-implemented.md).
+
+The "Files Changed" table describes state at authoring time and will drift by
+design; treat it as history, not current inventory.
+
+## Recommendation
+
+Re-run this check after **any** change to `frontend/lib/wallet.ts` or
+`wallet-connect.tsx`. Both findings are the kind that appear when code moves on
+and prose doesn't — and this document is cited elsewhere as authoritative, so its
+inaccuracies propagate.

--- a/bridgelet-product-audit/runbooks/diagnose-wallet-connection-failure.md
+++ b/bridgelet-product-audit/runbooks/diagnose-wallet-connection-failure.md
@@ -1,0 +1,50 @@
+# Runbook: Freighter Connection Failure
+
+## Step 1 — Is the extension installed and unlocked?
+
+`connectFreighter()` checks `freighter.isConnected()` first and, when false,
+throws a message written for exactly this case:
+
+> Freighter extension not found. Please install it from freighter.app and refresh.
+
+**If the user reports that message, believe it** — the extension is not
+detectable. Check, in order:
+
+- Is Freighter installed in the browser they're using **right now**? Users often
+  have it in one browser and hit Bridgelet in another.
+- Is it **enabled**? Profile switches and cleanup tools disable extensions.
+- Is it **unlocked**? A locked Freighter may not report as available.
+- **Did they refresh after installing?** The message says this for a reason — a
+  page loaded before installation won't see it. Most common resolution.
+
+Also confirm they aren't in a **private/incognito window**, where extensions are often disabled by default.
+
+## Step 2 — Was the popup blocked or dismissed?
+
+If the extension is detected, connection moves to `requestAccess()`, which opens
+the Freighter popup. Two distinct failures look identical to the user: the popup
+was **blocked**, or the user **dismissed/ignored** the approval prompt.
+
+The second has its own symptom worth asking about — without approval,
+`getAddress()` returns no address and the code throws:
+
+> Freighter did not return a public key. Did you approve the request?
+
+Have them open the console (`F12` → Console) and re-attempt while watching. Look
+for popup-blocked warnings and either message above, check for a blocked-popup
+icon in the address bar, then have them click the Freighter extension icon
+directly — a pending approval often waits there unseen.
+
+## Step 3 — Isolate extension-specific problems
+
+Have the user try **a different browser** with Freighter installed.
+
+- **Works elsewhere** → that browser profile is the problem: a conflicting
+  extension, hardened privacy settings, or a corrupted install. Reinstalling
+  Freighter there is the usual fix.
+- **Fails everywhere** → likely the Freighter install or account, not Bridgelet.
+  Version matters: `@stellar/freighter-api` is pinned here while users update the
+  extension independently, so a mismatch is possible — see
+  [`freighter-api-version-pinning.md`](../integration-notes/freighter-api-version-pinning.md).
+
+**When escalating,** include browser + version, OS, Freighter version, the exact message, console errors, and whether it reproduced in a second browser.


### PR DESCRIPTION
Adds 4 entries to the `bridgelet-product-audit/` knowledge base.

Closes #260
Closes #263
Closes #273
Closes #277

## Files added

| Path |
|---|
| `bridgelet-product-audit/glossary/analytics-spec-overview.md` |
| `bridgelet-product-audit/glossary/branch-protection-reference.md` |
| `bridgelet-product-audit/integration-notes/sender-auth-model-doc-accuracy.md` |
| `bridgelet-product-audit/runbooks/diagnose-wallet-connection-failure.md` |

## Notes

- **Documentation only.** No changes to `frontend/` or `mobile/`, matching each issue's stated scope.
- Every file is under 50 lines.
- Content was written against the current state of the code and docs rather than restating the issue text; where an issue's premise turned out not to match the code, the file records the discrepancy.
- Branched from `fbec7e4` (current upstream `main`), so the PR merges cleanly.