### PR TITLE
feat(nav): sticky navigation header with mobile menu

### DIFF
--- a/frontend/components/page-shell.tsx
+++ b/frontend/components/page-shell.tsx
@@ -1,7 +1,5 @@
-import Link from 'next/link';
 import type { ReactNode } from 'react';
-import Logo from './logo';
-import { ThemeToggle } from './theme-toggle';
+import { SiteNav } from './site-nav';
 
 type PageShellProps = {
   title: string;
@@ -14,21 +12,7 @@ type PageShellProps = {
 export function PageShell({ title, description, children, footer }: PageShellProps) {
   return (
     <div className="flex min-h-screen flex-col bg-slate-50 dark:bg-slate-950">
-      <nav className="border-b border-slate-200 bg-white px-6 py-3 dark:border-slate-800 dark:bg-slate-900">
-        <div className="flex items-center justify-between">
-          <Link
-            href="/"
-            aria-label="Bridgelet home"
-            className="flex items-center gap-2"
-          >
-            <Logo className="w-8 h-8" />
-            <span className="text-lg font-medium tracking-tight text-[#0A1628] dark:text-white">
-              bridgelet
-            </span>
-          </Link>
-          <ThemeToggle />
-        </div>
-      </nav>
+      <SiteNav />
       <main className="mx-auto flex w-full max-w-3xl flex-1 flex-col gap-6 px-6 py-12">
         <header className="space-y-2">
           <h1 className="text-3xl font-semibold tracking-tight text-slate-950">{title}</h1>

--- a/frontend/components/site-nav.test.tsx
+++ b/frontend/components/site-nav.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { ThemeProvider } from './theme-provider';
+import { SiteNav } from './site-nav';
+
+const mockPathname = vi.fn(() => '/');
+vi.mock('next/navigation', () => ({ usePathname: () => mockPathname() }));
+
+function renderNav(pathname = '/') {
+  mockPathname.mockReturnValue(pathname);
+  return render(
+    <ThemeProvider>
+      <SiteNav />
+    </ThemeProvider>,
+  );
+}
+
+describe('SiteNav', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove('dark');
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn().mockReturnValue({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() }),
+    );
+  });
+
+  it('renders the four nav links and the home logo link', () => {
+    renderNav();
+    const nav = screen.getByRole('navigation', { name: 'Main' });
+    for (const label of ['Home', 'Send', 'Docs', 'GitHub']) {
+      expect(within(nav).getAllByRole('link', { name: label }).length).toBeGreaterThan(0);
+    }
+    expect(within(nav).getByRole('link', { name: 'Bridgelet home' })).toBeInTheDocument();
+  });
+
+  it('marks the link matching the current route as the active page', () => {
+    renderNav('/send');
+    const [send] = screen.getAllByRole('link', { name: 'Send' });
+    const [home] = screen.getAllByRole('link', { name: 'Home' });
+    expect(send).toHaveAttribute('aria-current', 'page');
+    expect(home).not.toHaveAttribute('aria-current');
+  });
+
+  it('opens external links safely in a new tab', () => {
+    renderNav();
+    const [docs] = screen.getAllByRole('link', { name: 'Docs' });
+    expect(docs).toHaveAttribute('target', '_blank');
+    expect(docs).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(docs).not.toHaveAttribute('aria-current');
+  });
+
+  it('toggles the mobile menu from the hamburger button', () => {
+    renderNav();
+    const button = screen.getByRole('button', { name: 'Open menu' });
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByTestId('mobile-menu')).not.toBeInTheDocument();
+
+    fireEvent.click(button);
+    expect(screen.getByTestId('mobile-menu')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Close menu' })).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close menu' }));
+    expect(screen.queryByTestId('mobile-menu')).not.toBeInTheDocument();
+  });
+
+  it('closes the mobile menu when Escape is pressed', () => {
+    renderNav();
+    fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+    expect(screen.getByTestId('mobile-menu')).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByTestId('mobile-menu')).not.toBeInTheDocument();
+  });
+
+  it('closes the mobile menu on a click outside the nav', () => {
+    renderNav();
+    fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+    expect(screen.getByTestId('mobile-menu')).toBeInTheDocument();
+
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByTestId('mobile-menu')).not.toBeInTheDocument();
+  });
+
+  it('keeps the menu open when clicking inside the nav', () => {
+    renderNav();
+    fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+    fireEvent.mouseDown(screen.getByTestId('mobile-menu'));
+    expect(screen.getByTestId('mobile-menu')).toBeInTheDocument();
+  });
+
+  it('closes the mobile menu after following a link', () => {
+    renderNav();
+    fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+    const menu = screen.getByTestId('mobile-menu');
+    fireEvent.click(within(menu).getByRole('link', { name: 'Send' }));
+    expect(screen.queryByTestId('mobile-menu')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/components/site-nav.tsx
+++ b/frontend/components/site-nav.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useEffect, useRef, useState } from 'react';
+import Logo from './logo';
+import { ThemeToggle } from './theme-toggle';
+
+type NavLink = { href: string; label: string; external?: boolean };
+
+const LINKS: NavLink[] = [
+  { href: '/', label: 'Home' },
+  { href: '/send', label: 'Send' },
+  { href: 'https://github.com/bridgelet-org/bridgelet/tree/main/docs', label: 'Docs', external: true },
+  { href: 'https://github.com/bridgelet-org/bridgelet', label: 'GitHub', external: true },
+];
+
+const BASE = 'rounded px-3 py-2 text-sm font-medium transition-colors';
+const ACTIVE = 'bg-slate-100 text-[#0A1628] dark:bg-slate-800 dark:text-white';
+const IDLE = 'text-slate-600 hover:text-[#0A1628] dark:text-slate-300 dark:hover:text-white';
+
+export function SiteNav() {
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+  const navRef = useRef<HTMLElement | null>(null);
+
+  // Close the mobile menu on Escape or a click outside the nav.
+  useEffect(() => {
+    if (!open) return;
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') setOpen(false);
+    }
+    function onPointerDown(event: MouseEvent) {
+      if (navRef.current && !navRef.current.contains(event.target as Node)) setOpen(false);
+    }
+    document.addEventListener('keydown', onKeyDown);
+    document.addEventListener('mousedown', onPointerDown);
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      document.removeEventListener('mousedown', onPointerDown);
+    };
+  }, [open]);
+
+  function renderLink(link: NavLink) {
+    const active = !link.external && pathname === link.href;
+    const className = `${BASE} ${active ? ACTIVE : IDLE}`;
+    if (link.external) {
+      return (
+        <a
+          key={link.href}
+          href={link.href}
+          className={className}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={() => setOpen(false)}
+        >
+          {link.label}
+        </a>
+      );
+    }
+    return (
+      <Link
+        key={link.href}
+        href={link.href}
+        className={className}
+        aria-current={active ? 'page' : undefined}
+        onClick={() => setOpen(false)}
+      >
+        {link.label}
+      </Link>
+    );
+  }
+
+  return (
+    <nav
+      ref={navRef}
+      aria-label="Main"
+      className="sticky top-0 z-50 border-b border-slate-200 bg-white/95 backdrop-blur dark:border-slate-800 dark:bg-slate-900/95"
+    >
+      <div className="mx-auto flex max-w-5xl items-center justify-between gap-4 px-6 py-3">
+        <Link
+          href="/"
+          aria-label="Bridgelet home"
+          className="flex items-center gap-2"
+          onClick={() => setOpen(false)}
+        >
+          <Logo className="h-8 w-8" />
+          <span className="text-lg font-medium tracking-tight text-[#0A1628] dark:text-white">
+            bridgelet
+          </span>
+        </Link>
+
+        <div className="flex items-center gap-2">
+          <div className="hidden items-center gap-1 md:flex">{LINKS.map(renderLink)}</div>
+          <ThemeToggle />
+          <button
+            type="button"
+            className="inline-flex items-center rounded p-2 text-slate-600 md:hidden dark:text-slate-300"
+            aria-label={open ? 'Close menu' : 'Open menu'}
+            aria-expanded={open}
+            aria-controls="mobile-menu"
+            onClick={() => setOpen((value) => !value)}
+          >
+            <svg
+              viewBox="0 0 24 24"
+              className="h-6 w-6"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              aria-hidden="true"
+            >
+              {open ? <path d="M6 6l12 12M18 6L6 18" /> : <path d="M4 7h16M4 12h16M4 17h16" />}
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      {open && (
+        <div
+          id="mobile-menu"
+          data-testid="mobile-menu"
+          className="flex flex-col gap-1 border-t border-slate-200 px-6 py-3 md:hidden dark:border-slate-800"
+        >
+          {LINKS.map(renderLink)}
+        </div>
+      )}
+    </nav>
+  );
+}


### PR DESCRIPTION
Closes #182

Adds a sticky top navigation header with a mobile hamburger menu.

## What's included

- **`components/site-nav.tsx`** (new) — the header itself.
- **`components/site-nav.test.tsx`** (new) — 8 tests covering the behaviours below.
- **`components/page-shell.tsx`** — now renders `<SiteNav />` in place of its own inline nav.

## Acceptance criteria

| Requirement | How it's met |
|---|---|
| Sticky top navbar | `sticky top-0 z-50` with a translucent backdrop blur |
| Logo | Existing `<Logo />`, wrapped in a link to `/` |
| Nav links | Home, Send, Docs, GitHub |
| Hamburger menu on mobile | Button visible below `md`; link row hidden below `md` |
| Closes on outside click | `mousedown` listener, ignoring clicks inside the nav |
| Closes on Escape | `keydown` listener |
| Active link highlighted | Compared against `usePathname()`, plus `aria-current="page"` |
| Tests passing | 8 new tests; suite goes 95 -> 103 passing |

## Notes

- **No duplicate header.** All five pages render through `PageShell`, so swapping its inline nav for `SiteNav` gives every page the new header without stacking two navs. `ThemeToggle` moved into `SiteNav` so it is preserved.
- **Docs and GitHub are external links** (`target="_blank"` + `rel="noopener noreferrer"`). There is no `/docs` route in this app, so pointing at one would have produced a dead link; they point at the repository's `docs/` folder and root instead. Happy to change these to internal routes if a docs page is planned.
- **Accessibility:** `aria-label="Main"` on the nav (the homepage already has a nested `nav` labelled "Flow selection", so the label disambiguates them), `aria-expanded` / `aria-controls` on the toggle, and `aria-current` on the active link. This matters for the Lighthouse CI accessibility gate, which is set to fail below 0.95.
- Verified locally with the exact CI commands: `npm run lint`, `npm run typecheck`, `npm test`, `npm run build` — all pass.
- No existing document in `docs/` describes site navigation, so nothing there needed updating.

Branched from `fbec7e4` (current upstream `main`).