### PR TITLE
[146] Experiment: Freighter wallet for sender signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Comprehensive documentation is available in the [`/docs`](./docs) directory:
 | [💡 Use Cases & Examples](https://github.com/bridgelet-org/bridgelet/raw/main/docs/use-cases.pdf)      | Real-world use cases and examples                |
 | [📋 MVP Specification](https://github.com/bridgelet-org/bridgelet/raw/main/docs/mvp-specification.pdf) | Minimum viable product requirements              |
 | [🧪 Testing Guide](./TESTING.md)                                                                       | Testing strategy, Lighthouse CI, and guidelines  |
+| [🔐 Freighter Sender Signing Experiment](./docs/experiments/freighter-sender-signing.md)               | Client-side Freighter signing for account creation |
 
 > **📌 Note:** If PDFs don't render in your browser, click the links above to download them directly, or see the [docs directory](./docs) for more information.
 

--- a/docs/experiments/freighter-sender-signing.md
+++ b/docs/experiments/freighter-sender-signing.md
@@ -2,41 +2,80 @@
 
 ## Goal
 
-Evaluate a client-side sender-signing path where the browser asks Freighter to sign an unsigned account-creation transaction XDR, instead of relying only on backend signing keys.
+Evaluate a client-side sender-signing path where the browser asks Freighter to
+sign an unsigned account-creation transaction XDR, instead of relying only on
+backend signing keys.
 
 ## Implemented Flow
 
 1. Sender connects Freighter in the send flow.
-2. On Confirm, frontend attempts `POST /api/accounts/prepare` with the account payload.
-3. If `unsignedTxXdr` is returned, frontend signs via Freighter `signTransaction`.
-4. Frontend submits `POST /api/accounts` with:
+2. On Confirm, frontend orchestration (`lib/freighter-sender-signing.ts`) checks
+   the experiment feature flag and Freighter signing availability.
+3. Frontend calls `POST /api/accounts/prepare` (Next.js proxy to
+   `BRIDGELET_SDK_URL/accounts/prepare`) with the account payload.
+4. If `unsignedTxXdr` is returned, frontend signs via Freighter `signTransaction`.
+5. Frontend verifies the Freighter signer address matches `fundingSource`.
+6. Frontend submits `POST /api/accounts` with:
    - the original account-creation payload
    - `signedTxXdr`
    - `signerAddress`
    - `networkPassphrase`
    - `signingMode: "freighter-client"`
-5. If prepare/sign is unavailable, frontend falls back to existing backend signing path.
+7. If prepare/sign is unavailable, frontend falls back to the existing backend
+   signing path.
+
+## Feature Flag
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `NEXT_PUBLIC_ENABLE_FREIGHTER_SENDER_SIGNING` | enabled | Set to `false` / `0` / `off` to force backend signing only |
 
 ## Why Fallback Exists
 
-This is intentionally experimental. Some environments may not yet implement the `prepare` endpoint or may not expose transaction signing capabilities. Fallback keeps the sender flow operational while the experiment rolls out.
+This is intentionally experimental. Some environments may not yet implement the
+`prepare` endpoint or may not expose transaction signing capabilities. Fallback
+keeps the sender flow operational while the experiment rolls out.
+
+Fallback is **not** used when:
+
+- the user rejects the Freighter signing prompt
+- Freighter returns a signer address that does not match the funding wallet
+- Freighter returns an empty/invalid signed XDR
 
 ## Security Tradeoffs
 
 Pros:
+
 - Reduces backend custody over sender signing for account creation.
 - Sender private key remains in wallet extension; browser receives only signed XDR.
 - Improves non-custodial posture for funding authorization.
+- Signer/funding-source equality check reduces accidental cross-account signing.
 
 Cons / Risks:
+
 - Browser-side signing adds wallet/API dependency and extension UX failure modes.
-- Unsigned XDR still originates from backend; integrity checks are required server-side.
-- Fallback path can hide rollout gaps unless monitored.
+- Unsigned XDR still originates from backend; integrity checks are required
+  server-side (signature verification, amount/destination binding).
+- Fallback path can hide rollout gaps unless monitored (log `signingMode` and
+  fallback reason).
+- Prepare proxy still trusts `BRIDGELET_SDK_TOKEN` server-side; keep that secret
+  out of the browser bundle.
+
+## Files
+
+| Path | Role |
+| --- | --- |
+| `frontend/app/api/accounts/prepare/route.ts` | Proxy prepare endpoint |
+| `frontend/lib/freighter-sender-signing.ts` | Experiment orchestration |
+| `frontend/lib/wallet.ts` | Freighter connect + `signTransaction` helpers |
+| `frontend/components/send-form/steps/confirm-step.tsx` | Send confirm UX |
 
 ## Validation Checklist
 
 - Frontend typecheck passes.
-- Frontend tests pass, including wallet signing helper tests.
+- Frontend tests pass, including wallet signing helper tests and Freighter
+  confirm-step coverage.
 - Manual send flow test:
   - Freighter installed path attempts prepare/sign/submit.
+  - User rejection shows an error (no silent backend fallback).
   - Missing-prepare path falls back and still returns claim URL.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -10,6 +10,10 @@ NEXT_PUBLIC_CRYPTO_NETWORK=stellar-testnet
 # Human support destination shown on error fallback states.
 NEXT_PUBLIC_SUPPORT_EMAIL=support@example.com
 
+# Experimental Freighter client-side sender signing for account creation.
+# Defaults to enabled when unset. Set to false to force backend signing only.
+NEXT_PUBLIC_ENABLE_FREIGHTER_SENDER_SIGNING=true
+
 # Public API key sent as X-API-Key on protected bridgelet-sdk requests
 # (account creation/lookup). Leave empty for local development.
 NEXT_PUBLIC_API_KEY=

--- a/frontend/app/api/accounts/_proxy.ts
+++ b/frontend/app/api/accounts/_proxy.ts
@@ -1,0 +1,95 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const SDK_URL = process.env.BRIDGELET_SDK_URL;
+const SDK_TOKEN = process.env.BRIDGELET_SDK_TOKEN;
+
+const UPSTREAM_TIMEOUT_MS = 10_000;
+
+const FORWARDABLE_RESPONSE_HEADERS = ['content-type', 'retry-after'];
+
+class ConfigError extends Error {}
+
+function assertConfigured(): { sdkUrl: string; sdkToken: string } {
+  if (!SDK_URL || !SDK_TOKEN) {
+    console.error(
+      '[bridgelet/accounts] Missing required env vars: BRIDGELET_SDK_URL and/or BRIDGELET_SDK_TOKEN',
+    );
+    throw new ConfigError();
+  }
+  return { sdkUrl: SDK_URL, sdkToken: SDK_TOKEN };
+}
+
+function buildResponseHeaders(upstream: Response): Headers {
+  const headers = new Headers();
+  for (const key of FORWARDABLE_RESPONSE_HEADERS) {
+    const value = upstream.headers.get(key);
+    if (value) headers.set(key, value);
+  }
+  if (!headers.has('content-type')) {
+    headers.set('content-type', 'application/json');
+  }
+  headers.set('Cache-Control', 'no-store');
+  return headers;
+}
+
+export function getRequestId(req: NextRequest): string {
+  return req.headers.get('x-request-id') ?? crypto.randomUUID();
+}
+
+export async function forwardAccountsRequest(
+  path: string,
+  init: RequestInit,
+  requestId: string,
+): Promise<NextResponse> {
+  let sdkUrl: string;
+  let sdkToken: string;
+  try {
+    ({ sdkUrl, sdkToken } = assertConfigured());
+  } catch {
+    return NextResponse.json({ error: 'Service temporarily unavailable' }, { status: 503 });
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), UPSTREAM_TIMEOUT_MS);
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(`${sdkUrl}${path}`, {
+      ...init,
+      headers: {
+        ...(init.headers ?? {}),
+        Authorization: `Bearer ${sdkToken}`,
+        'X-Request-Id': requestId,
+      },
+      signal: controller.signal,
+    });
+  } catch (err) {
+    const isAbort = err instanceof Error && err.name === 'AbortError';
+    console.error(
+      `[bridgelet/accounts] upstream fetch failed (requestId=${requestId})`,
+      isAbort ? 'timed out' : err,
+    );
+    return NextResponse.json(
+      { error: isAbort ? 'Upstream request timed out' : 'Upstream request failed' },
+      { status: isAbort ? 504 : 502 },
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  const data = await upstream.text();
+  return new NextResponse(data, {
+    status: upstream.status,
+    headers: buildResponseHeaders(upstream),
+  });
+}
+
+export function parseJsonBodyOrError(raw: string): NextResponse | null {
+  if (raw.length === 0) return null;
+  try {
+    JSON.parse(raw);
+    return null;
+  } catch {
+    return NextResponse.json({ error: 'Request body must be valid JSON' }, { status: 400 });
+  }
+}

--- a/frontend/app/api/accounts/prepare/route.ts
+++ b/frontend/app/api/accounts/prepare/route.ts
@@ -3,11 +3,19 @@ import {
   forwardAccountsRequest,
   getRequestId,
   parseJsonBodyOrError,
-} from './_proxy';
+} from '../_proxy';
 
 export const dynamic = 'force-dynamic';
 export const fetchCache = 'force-no-store';
 
+/**
+ * Experimental Freighter sender-signing prepare endpoint.
+ *
+ * Proxies account-creation payloads to the SDK's `/accounts/prepare` route,
+ * which returns an unsigned transaction XDR for client-side wallet signing.
+ * When the SDK does not implement prepare yet, upstream 404/501 responses
+ * intentionally surface so the send UI can fall back to backend signing.
+ */
 export async function POST(req: NextRequest) {
   const requestId = getRequestId(req);
   const raw = await req.text();
@@ -16,7 +24,7 @@ export async function POST(req: NextRequest) {
   if (parseError) return parseError;
 
   return forwardAccountsRequest(
-    '/accounts',
+    '/accounts/prepare',
     {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -24,11 +32,4 @@ export async function POST(req: NextRequest) {
     },
     requestId,
   );
-}
-
-export async function GET(req: NextRequest) {
-  const requestId = getRequestId(req);
-  const qs = req.nextUrl.search;
-
-  return forwardAccountsRequest('/accounts' + qs, { method: 'GET' }, requestId);
 }

--- a/frontend/app/claim/[token]/page.tsx
+++ b/frontend/app/claim/[token]/page.tsx
@@ -26,7 +26,7 @@ export default async function ClaimPage({ params }: ClaimPageProps) {
           initialView={initialView}
         />
 
-        <p className="text-xs text-slate-400 text-center">
+        <p className="text-xs text-slate-500 text-center">
           Token: <span className="font-mono break-all">{token}</span>
         </p>
 

--- a/frontend/components/claim-status-card.tsx
+++ b/frontend/components/claim-status-card.tsx
@@ -353,7 +353,7 @@ function ExpiredPanel({
         <div>
           <p className="text-sm font-semibold text-red-800">This claim link has expired</p>
           {expiresAt && (
-            <p className="text-xs text-red-600 mt-0.5">Expired on {formatExpiry(expiresAt)}.</p>
+            <p className="text-xs text-red-700 mt-0.5">Expired on {formatExpiry(expiresAt)}.</p>
           )}
         </div>
       </div>
@@ -400,7 +400,7 @@ function FailedPanel({ supportEmail }: Pick<ClaimStatusCardProps, 'supportEmail'
         </svg>
         <div>
           <p className="text-sm font-semibold text-red-800">This payment couldn&apos;t be set up</p>
-          <p className="text-xs text-red-600 mt-0.5">
+          <p className="text-xs text-red-700 mt-0.5">
             Something went wrong while creating or funding this payment. It has not been claimed and
             no funds have moved.
           </p>

--- a/frontend/components/clainStatusCard.test.tsx
+++ b/frontend/components/clainStatusCard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ClaimStatusCard } from './claim-status-card';
 import { RateLimitError } from '@/lib/api/client';
@@ -19,6 +19,11 @@ vi.mock('@/components/chain-selector', () => ({
 
 // A valid-looking Stellar public key (G + 55 base32 chars).
 const VALID_ADDRESS = 'G' + 'A'.repeat(55);
+
+function setDestinationAddress(value: string) {
+  const input = screen.getByLabelText(/your stellar wallet address/i);
+  fireEvent.change(input, { target: { value } });
+}
 
 describe('ClaimStatusCard', () => {
   // ─── INITIALIZING / PENDING_PAYMENT ────────────────────────────────────
@@ -57,24 +62,21 @@ describe('ClaimStatusCard', () => {
       expect(screen.getByText('—')).toBeInTheDocument();
     });
 
-    it('disables the claim button until a valid address is entered', async () => {
-      const user = userEvent.setup();
+    it('disables the claim button until a valid address is entered', () => {
       render(<ClaimStatusCard status={AccountStatus.PENDING_CLAIM} amountStroops="10000000" />);
       const button = screen.getByRole('button', { name: /claim now/i });
       expect(button).toBeDisabled();
 
-      const input = screen.getByLabelText(/your stellar wallet address/i);
-      await user.type(input, 'not-a-valid-address');
+      setDestinationAddress('not-a-valid-address');
       expect(button).toBeDisabled();
       expect(screen.getByText(/enter a valid stellar public key/i)).toBeInTheDocument();
 
-      await user.clear(input);
-      await user.type(input, VALID_ADDRESS);
+      setDestinationAddress(VALID_ADDRESS);
       expect(button).toBeEnabled();
     });
 
     it('calls onClaim with the destination address and shows success state', async () => {
-      const user = userEvent.setup();
+      const user = userEvent.setup({ delay: null });
       const onClaim = vi.fn().mockResolvedValue(undefined);
       render(
         <ClaimStatusCard
@@ -85,8 +87,7 @@ describe('ClaimStatusCard', () => {
         />,
       );
 
-      const input = screen.getByLabelText(/your stellar wallet address/i);
-      await user.type(input, VALID_ADDRESS);
+      setDestinationAddress(VALID_ADDRESS);
       await user.click(screen.getByRole('button', { name: /claim now/i }));
 
       await waitFor(() => expect(onClaim).toHaveBeenCalledWith(VALID_ADDRESS));
@@ -95,7 +96,7 @@ describe('ClaimStatusCard', () => {
     });
 
     it('shows a rate limit banner when onClaim throws RateLimitError', async () => {
-      const user = userEvent.setup();
+      const user = userEvent.setup({ delay: null });
       const onClaim = vi.fn().mockRejectedValue(new RateLimitError(30));
       render(
         <ClaimStatusCard
@@ -105,8 +106,7 @@ describe('ClaimStatusCard', () => {
         />,
       );
 
-      const input = screen.getByLabelText(/your stellar wallet address/i);
-      await user.type(input, VALID_ADDRESS);
+      setDestinationAddress(VALID_ADDRESS);
       await user.click(screen.getByRole('button', { name: /claim now/i }));
 
       expect(await screen.findByTestId('rate-limit-banner')).toHaveTextContent('retry: 30');
@@ -115,7 +115,7 @@ describe('ClaimStatusCard', () => {
     });
 
     it('shows a visible error message for a non-rate-limit rejection', async () => {
-      const user = userEvent.setup();
+      const user = userEvent.setup({ delay: null });
       const onClaim = vi.fn().mockRejectedValue(new Error('boom'));
       render(
         <ClaimStatusCard
@@ -125,8 +125,7 @@ describe('ClaimStatusCard', () => {
         />,
       );
 
-      const input = screen.getByLabelText(/your stellar wallet address/i);
-      await user.type(input, VALID_ADDRESS);
+      setDestinationAddress(VALID_ADDRESS);
       await user.click(screen.getByRole('button', { name: /claim now/i }));
 
       expect(await screen.findByRole('alert')).toHaveTextContent('boom');
@@ -134,7 +133,7 @@ describe('ClaimStatusCard', () => {
     });
 
     it('clears a previous error on the next claim attempt', async () => {
-      const user = userEvent.setup();
+      const user = userEvent.setup({ delay: null });
       const onClaim = vi
         .fn()
         .mockRejectedValueOnce(new Error('boom'))
@@ -147,8 +146,7 @@ describe('ClaimStatusCard', () => {
         />,
       );
 
-      const input = screen.getByLabelText(/your stellar wallet address/i);
-      await user.type(input, VALID_ADDRESS);
+      setDestinationAddress(VALID_ADDRESS);
       const button = screen.getByRole('button', { name: /claim now/i });
       await user.click(button);
       expect(await screen.findByRole('alert')).toBeInTheDocument();

--- a/frontend/components/send-form/index.tsx
+++ b/frontend/components/send-form/index.tsx
@@ -88,7 +88,7 @@ export function SendForm() {
                 <span
                   aria-current={isCurrent ? 'step' : undefined}
                   className={`text-xs font-medium ${
-                    isCurrent ? 'text-slate-900' : isDone ? 'text-green-600' : 'text-slate-400'
+                    isCurrent ? 'text-slate-900' : isDone ? 'text-green-700' : 'text-slate-500'
                   }`}
                 >
                   {i + 1}. {s.charAt(0).toUpperCase() + s.slice(1)}

--- a/frontend/components/send-form/steps/confirm-step.tsx
+++ b/frontend/components/send-form/steps/confirm-step.tsx
@@ -3,9 +3,13 @@
 import { useState } from 'react';
 import type { SendFormState } from '../index';
 import { useNfc } from '@/hooks/use-nfc';
-import { BridgeletClient, RateLimitError, BridgeletApiError } from '@/lib/api/client';
+import { BridgeletClient, RateLimitError } from '@/lib/api/client';
 import { createEphemeralAccount, type EphemeralAccount } from '@/lib/bridgelet';
-import { isFreighterTransactionSigningAvailable, signFreighterTransaction } from '@/lib/wallet';
+import {
+  FreighterSenderSigningError,
+  toCreateAccountRequestWithFreighterSignature,
+  tryFreighterSenderSigning,
+} from '@/lib/freighter-sender-signing';
 import {
   classifyAccountCreationError,
   AccountCreationErrorCode,
@@ -24,16 +28,18 @@ const MAX_RETRIES = 3;
 
 const client = new BridgeletClient();
 
-function formatExpiryLabel(seconds: number): string {
-  const days = Math.round(seconds / (24 * 60 * 60));
-  if (days === 1) return '24 hours';
-  if (days < 7) return `${days} days`;
-  if (days === 7) return '7 days';
-  if (days === 30) return '30 days';
-  return `${days} days`;
-}
-
 function classifyError(err: unknown): AccountCreationErrorInfo {
+  if (err instanceof FreighterSenderSigningError) {
+    return {
+      code: AccountCreationErrorCode.INVALID_REQUEST,
+      userMessage: err.message,
+      retryable: err.code === 'USER_REJECTED',
+      suggestion:
+        err.code === 'SIGNER_MISMATCH'
+          ? 'Reconnect the Freighter wallet that funds this payment, then try again.'
+          : 'Approve the Freighter prompt, or go back and reconnect your wallet.',
+    };
+  }
   if (err instanceof RateLimitError) {
     return {
       code: AccountCreationErrorCode.RATE_LIMITED,
@@ -50,8 +56,14 @@ type ConfirmStepProps = {
   onBack: () => void;
 };
 
+type SubmitPhase = 'idle' | 'preparing' | 'awaiting-freighter' | 'submitting';
+
 export function ConfirmStep({ state, onBack }: ConfirmStepProps) {
   const [submitting, setSubmitting] = useState(false);
+  const [submitPhase, setSubmitPhase] = useState<SubmitPhase>('idle');
+  const [signingModeUsed, setSigningModeUsed] = useState<'freighter-client' | 'backend' | null>(
+    null,
+  );
   const [submitted, setSubmitted] = useState(false);
   const [errorInfo, setErrorInfo] = useState<AccountCreationErrorInfo | null>(null);
   const [retryCount, setRetryCount] = useState(0);
@@ -74,48 +86,27 @@ export function ConfirmStep({ state, onBack }: ConfirmStepProps) {
     };
   }
 
-  function canFallbackToBackendSigning(err: unknown): boolean {
-    if (err instanceof BridgeletApiError && [404, 405, 422, 501].includes(err.statusCode)) {
-      return true;
-    }
-
-    if (!(err instanceof Error)) return false;
-    return (
-      err.message.includes('Missing unsigned transaction XDR') ||
-      err.message.includes('Freighter transaction signing is not available') ||
-      err.message.includes('did not return a signed transaction')
-    );
-  }
-
   async function executeCreateAccount(attempt: number) {
     setSubmitting(true);
+    setSubmitPhase('preparing');
     setErrorInfo(null);
     setRetryAfter(null);
     try {
       const payload = buildCreateAccountPayload();
 
+      setSubmitPhase('awaiting-freighter');
+      const signing = await tryFreighterSenderSigning(client, payload);
+
+      setSubmitPhase('submitting');
       let account: EphemeralAccount;
-
-      try {
-        if (isFreighterTransactionSigningAvailable()) {
-          const prepared = await client.prepareAccountTransaction(payload);
-          const signed = await signFreighterTransaction(prepared.unsignedTxXdr);
-          account = await createEphemeralAccount({
-            ...payload,
-            signedTxXdr: signed.signedTxXdr,
-            signerAddress: signed.signerAddress,
-            networkPassphrase: signed.networkPassphrase,
-            signingMode: 'freighter-client',
-          });
-        } else {
-          account = await createEphemeralAccount(payload);
-        }
-      } catch (err) {
-        if (!canFallbackToBackendSigning(err)) {
-          throw err;
-        }
-
+      if (signing.mode === 'freighter-client') {
+        account = await createEphemeralAccount(
+          toCreateAccountRequestWithFreighterSignature(payload, signing.signed),
+        );
+        setSigningModeUsed('freighter-client');
+      } else {
         account = await createEphemeralAccount(payload);
+        setSigningModeUsed('backend');
       }
 
       if (!account.claimUrl) {
@@ -137,6 +128,7 @@ export function ConfirmStep({ state, onBack }: ConfirmStepProps) {
       setRetryCount(attempt);
     } finally {
       setSubmitting(false);
+      setSubmitPhase('idle');
     }
   }
 
@@ -148,6 +140,12 @@ export function ConfirmStep({ state, onBack }: ConfirmStepProps) {
     const nextAttempt = retryCount + 1;
     if (nextAttempt > MAX_RETRIES) return;
     executeCreateAccount(nextAttempt);
+  }
+
+  function submittingLabel(): string {
+    if (submitPhase === 'awaiting-freighter') return 'Waiting for Freighter…';
+    if (submitPhase === 'preparing') return 'Preparing transaction…';
+    return 'Sending…';
   }
 
   if (submitted) {
@@ -166,8 +164,14 @@ export function ConfirmStep({ state, onBack }: ConfirmStepProps) {
           ) : (
             <>Your claim link is ready to share with your recipient.</>
           )}{' '}
-          They have 24 hours to claim their funds.
+          They have {formatExpiryLabel(state.expiresIn || DEFAULT_EXPIRES_IN_SECONDS)} to claim
+          their funds.
         </p>
+        {signingModeUsed === 'freighter-client' && (
+          <p className="mt-2 text-xs text-green-700">
+            Account creation was authorised with Freighter client-side signing.
+          </p>
+        )}
 
         {isSupported && claimUrl && (
           <div className="mt-4 border-t border-green-200 pt-4">
@@ -225,6 +229,10 @@ export function ConfirmStep({ state, onBack }: ConfirmStepProps) {
             <dd className="text-slate-600">{state.memo}</dd>
           </div>
         )}
+        <div className="flex justify-between py-1.5">
+          <dt className="font-medium text-slate-700">Signing</dt>
+          <dd className="text-slate-600">Freighter (experimental) with backend fallback</dd>
+        </div>
       </dl>
 
       {errorInfo && (
@@ -273,7 +281,7 @@ export function ConfirmStep({ state, onBack }: ConfirmStepProps) {
             disabled={submitting}
             className="rounded-lg bg-red-700 px-4 py-2 text-sm font-medium text-white transition hover:bg-red-800 disabled:opacity-60"
           >
-            {submitting ? 'Retrying…' : `Try Again (${MAX_RETRIES - retryCount} left)`}
+            {submitting ? submittingLabel() : `Try Again (${MAX_RETRIES - retryCount} left)`}
           </button>
         ) : (
           <button
@@ -282,7 +290,7 @@ export function ConfirmStep({ state, onBack }: ConfirmStepProps) {
             disabled={submitting}
             className="rounded-lg bg-slate-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-700 disabled:opacity-60"
           >
-            {submitting ? 'Sending…' : 'Confirm & Send'}
+            {submitting ? submittingLabel() : 'Confirm & Send'}
           </button>
         )}
       </div>
@@ -301,4 +309,13 @@ export function ConfirmStep({ state, onBack }: ConfirmStepProps) {
       )}
     </div>
   );
+}
+
+function formatExpiryLabel(seconds: number): string {
+  const days = Math.round(seconds / (24 * 60 * 60));
+  if (days === 1) return '24 hours';
+  if (days < 7) return `${days} days`;
+  if (days === 7) return '7 days';
+  if (days === 30) return '30 days';
+  return `${days} days`;
 }

--- a/frontend/components/toast-provider.tsx
+++ b/frontend/components/toast-provider.tsx
@@ -38,6 +38,7 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
     <ToastContext.Provider value={value}>
       {children}
       <div
+        role="region"
         aria-live="polite"
         aria-label="Notifications"
         className="pointer-events-none fixed bottom-4 right-4 z-50 flex flex-col gap-2 sm:max-w-sm"

--- a/frontend/lib/freighter-sender-signing.test.ts
+++ b/frontend/lib/freighter-sender-signing.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BridgeletApiError } from '@/lib/create-bridgelet-client';
+import {
+  FreighterSenderSigningError,
+  isFreighterSenderSigningEnabled,
+  isPrepareUnavailableError,
+  isUserRejectedSigningError,
+  toCreateAccountRequestWithFreighterSignature,
+  tryFreighterSenderSigning,
+} from '@/lib/freighter-sender-signing';
+
+vi.mock('@/lib/wallet', () => ({
+  isFreighterTransactionSigningAvailable: vi.fn(),
+  signFreighterTransaction: vi.fn(),
+}));
+
+import {
+  isFreighterTransactionSigningAvailable,
+  signFreighterTransaction,
+} from '@/lib/wallet';
+
+const PAYLOAD = {
+  fundingSource: 'G' + 'A'.repeat(55),
+  recovery_address: 'G' + 'A'.repeat(55),
+  amount: '10',
+  expiresIn: 86400,
+};
+
+describe('freighter-sender-signing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.NEXT_PUBLIC_ENABLE_FREIGHTER_SENDER_SIGNING;
+    vi.mocked(isFreighterTransactionSigningAvailable).mockReturnValue(true);
+  });
+
+  it('defaults the experiment feature flag to enabled', () => {
+    expect(isFreighterSenderSigningEnabled()).toBe(true);
+  });
+
+  it('disables the experiment when the feature flag is off', () => {
+    process.env.NEXT_PUBLIC_ENABLE_FREIGHTER_SENDER_SIGNING = 'false';
+    expect(isFreighterSenderSigningEnabled()).toBe(false);
+  });
+
+  it('detects prepare-unavailable API statuses', () => {
+    expect(isPrepareUnavailableError(new BridgeletApiError({}, 404))).toBe(true);
+    expect(isPrepareUnavailableError(new BridgeletApiError({}, 501))).toBe(true);
+    expect(isPrepareUnavailableError(new BridgeletApiError({}, 500))).toBe(false);
+  });
+
+  it('detects Freighter user rejection messages', () => {
+    expect(isUserRejectedSigningError(new Error('User rejected the request'))).toBe(true);
+    expect(isUserRejectedSigningError(new Error('network failed'))).toBe(false);
+  });
+
+  it('returns freighter-client mode when prepare and sign succeed', async () => {
+    const client = {
+      prepareAccountTransaction: vi.fn().mockResolvedValue({ unsignedTxXdr: 'AAAA_UNSIGNED' }),
+    };
+    vi.mocked(signFreighterTransaction).mockResolvedValue({
+      signedTxXdr: 'AAAA_SIGNED',
+      signerAddress: PAYLOAD.fundingSource,
+      networkPassphrase: 'Test SDF Network ; September 2015',
+    });
+
+    const result = await tryFreighterSenderSigning(client, PAYLOAD);
+
+    expect(result.mode).toBe('freighter-client');
+    if (result.mode === 'freighter-client') {
+      expect(result.signed.signedTxXdr).toBe('AAAA_SIGNED');
+      expect(
+        toCreateAccountRequestWithFreighterSignature(PAYLOAD, result.signed).signingMode,
+      ).toBe('freighter-client');
+    }
+  });
+
+  it('falls back to backend when prepare is unavailable', async () => {
+    const client = {
+      prepareAccountTransaction: vi
+        .fn()
+        .mockRejectedValue(new BridgeletApiError({ message: 'not found' }, 404)),
+    };
+
+    await expect(tryFreighterSenderSigning(client, PAYLOAD)).resolves.toEqual({
+      mode: 'backend',
+      reason: 'prepare-unavailable',
+    });
+  });
+
+  it('falls back to backend when Freighter signing API is unavailable', async () => {
+    vi.mocked(isFreighterTransactionSigningAvailable).mockReturnValue(false);
+    const client = {
+      prepareAccountTransaction: vi.fn(),
+    };
+
+    await expect(tryFreighterSenderSigning(client, PAYLOAD)).resolves.toEqual({
+      mode: 'backend',
+      reason: 'freighter-signing-unavailable',
+    });
+    expect(client.prepareAccountTransaction).not.toHaveBeenCalled();
+  });
+
+  it('throws when the signer address does not match the funding source', async () => {
+    const client = {
+      prepareAccountTransaction: vi.fn().mockResolvedValue({ unsignedTxXdr: 'AAAA_UNSIGNED' }),
+    };
+    vi.mocked(signFreighterTransaction).mockResolvedValue({
+      signedTxXdr: 'AAAA_SIGNED',
+      signerAddress: 'G' + 'B'.repeat(55),
+      networkPassphrase: 'Test SDF Network ; September 2015',
+    });
+
+    await expect(tryFreighterSenderSigning(client, PAYLOAD)).rejects.toBeInstanceOf(
+      FreighterSenderSigningError,
+    );
+  });
+
+  it('throws when the user rejects Freighter signing (no backend fallback)', async () => {
+    const client = {
+      prepareAccountTransaction: vi.fn().mockResolvedValue({ unsignedTxXdr: 'AAAA_UNSIGNED' }),
+    };
+    vi.mocked(signFreighterTransaction).mockRejectedValue(new Error('User declined request'));
+
+    await expect(tryFreighterSenderSigning(client, PAYLOAD)).rejects.toMatchObject({
+      code: 'USER_REJECTED',
+    });
+  });
+});

--- a/frontend/lib/freighter-sender-signing.ts
+++ b/frontend/lib/freighter-sender-signing.ts
@@ -1,0 +1,137 @@
+import {
+  BridgeletApiError,
+  type BridgeletClient,
+  type PreparedAccountTransaction,
+} from '@/lib/create-bridgelet-client';
+import type { CreateAccountRequest } from '@/lib/bridgelet';
+import {
+  isFreighterTransactionSigningAvailable,
+  signFreighterTransaction,
+  type SignedFreighterTransaction,
+} from '@/lib/wallet';
+
+export type FreighterSigningMode = 'freighter-client' | 'backend';
+
+export type FreighterSenderSigningResult =
+  | {
+      mode: 'freighter-client';
+      signed: SignedFreighterTransaction;
+      prepared: PreparedAccountTransaction;
+    }
+  | {
+      mode: 'backend';
+      reason: string;
+    };
+
+export class FreighterSenderSigningError extends Error {
+  readonly code: 'USER_REJECTED' | 'SIGNER_MISMATCH' | 'SIGNING_FAILED';
+
+  constructor(code: FreighterSenderSigningError['code'], message: string) {
+    super(message);
+    this.name = 'FreighterSenderSigningError';
+    this.code = code;
+  }
+}
+
+/** Feature flag for the Freighter sender-signing experiment (default: enabled). */
+export function isFreighterSenderSigningEnabled(): boolean {
+  const raw = process.env['NEXT_PUBLIC_ENABLE_FREIGHTER_SENDER_SIGNING'];
+  if (raw == null || raw.trim() === '') return true;
+  return !['0', 'false', 'off', 'no'].includes(raw.trim().toLowerCase());
+}
+
+export function isPrepareUnavailableError(err: unknown): boolean {
+  if (err instanceof BridgeletApiError && [404, 405, 422, 501].includes(err.statusCode)) {
+    return true;
+  }
+  if (!(err instanceof Error)) return false;
+  return (
+    err.message.includes('Missing unsigned transaction XDR') ||
+    err.message.includes('Freighter transaction signing is not available')
+  );
+}
+
+export function isUserRejectedSigningError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const message = err.message.toLowerCase();
+  return (
+    message.includes('user rejected') ||
+    message.includes('user declined') ||
+    message.includes('rejected by user') ||
+    message.includes('denied by the user') ||
+    message.includes('request was rejected')
+  );
+}
+
+/**
+ * Attempt experimental Freighter client-side signing for account creation.
+ * Returns backend mode (with reason) when prepare/signing is unavailable.
+ * Throws FreighterSenderSigningError when the user rejects or signer mismatches.
+ */
+export async function tryFreighterSenderSigning(
+  client: Pick<BridgeletClient, 'prepareAccountTransaction'>,
+  payload: CreateAccountRequest,
+): Promise<FreighterSenderSigningResult> {
+  if (!isFreighterSenderSigningEnabled()) {
+    return { mode: 'backend', reason: 'feature-flag-disabled' };
+  }
+
+  if (!isFreighterTransactionSigningAvailable()) {
+    return { mode: 'backend', reason: 'freighter-signing-unavailable' };
+  }
+
+  let prepared: PreparedAccountTransaction;
+  try {
+    prepared = await client.prepareAccountTransaction(payload);
+  } catch (err) {
+    if (isPrepareUnavailableError(err)) {
+      return { mode: 'backend', reason: 'prepare-unavailable' };
+    }
+    throw err;
+  }
+
+  if (!prepared.unsignedTxXdr?.trim()) {
+    return { mode: 'backend', reason: 'missing-unsigned-xdr' };
+  }
+
+  let signed: SignedFreighterTransaction;
+  try {
+    signed = await signFreighterTransaction(prepared.unsignedTxXdr);
+  } catch (err) {
+    if (isUserRejectedSigningError(err)) {
+      throw new FreighterSenderSigningError(
+        'USER_REJECTED',
+        'Freighter signing was cancelled. Confirm again when you are ready to approve the transaction.',
+      );
+    }
+    if (isPrepareUnavailableError(err)) {
+      return { mode: 'backend', reason: 'freighter-signing-unavailable' };
+    }
+    throw new FreighterSenderSigningError(
+      'SIGNING_FAILED',
+      err instanceof Error ? err.message : 'Freighter signing failed.',
+    );
+  }
+
+  if (signed.signerAddress !== payload.fundingSource) {
+    throw new FreighterSenderSigningError(
+      'SIGNER_MISMATCH',
+      'Connected Freighter account does not match the funding wallet for this payment.',
+    );
+  }
+
+  return { mode: 'freighter-client', signed, prepared };
+}
+
+export function toCreateAccountRequestWithFreighterSignature(
+  payload: CreateAccountRequest,
+  signed: SignedFreighterTransaction,
+): CreateAccountRequest {
+  return {
+    ...payload,
+    signedTxXdr: signed.signedTxXdr,
+    signerAddress: signed.signerAddress,
+    networkPassphrase: signed.networkPassphrase,
+    signingMode: 'freighter-client',
+  };
+}

--- a/frontend/test-result/tests/components/send-form/steps/confirm-step.test.tsx
+++ b/frontend/test-result/tests/components/send-form/steps/confirm-step.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { BridgeletApiError, RateLimitError } from '../../../../../lib/create-bridgelet-client';
+import { BridgeletApiError } from '../../../../../lib/create-bridgelet-client';
 import { ConfirmStep } from '../../../../../components/send-form/steps/confirm-step';
 
 vi.mock('../../../../../hooks/use-nfc', () => ({
@@ -23,9 +23,12 @@ vi.mock('../../../../../lib/env', () => ({
 }));
 
 let createAccountImpl: () => Promise<any>;
+let prepareImpl: () => Promise<any>;
 
 vi.mock('../../../../../lib/create-bridgelet-client', async () => {
-  const actual = await vi.importActual<typeof import('../../../../../lib/create-bridgelet-client')>('../../../../../lib/create-bridgelet-client');
+  const actual = await vi.importActual<
+    typeof import('../../../../../lib/create-bridgelet-client')
+  >('../../../../../lib/create-bridgelet-client');
 
   return {
     ...actual,
@@ -34,20 +37,27 @@ vi.mock('../../../../../lib/create-bridgelet-client', async () => {
         return createAccountImpl();
       }
       override prepareAccountTransaction(): Promise<any> {
-        return Promise.resolve({ unsignedTxXdr: 'test' });
+        return prepareImpl();
       }
     },
   };
 });
 
 vi.mock('../../../../../lib/wallet', async () => {
-  const actual = await vi.importActual<typeof import('../../../../../lib/wallet')>('../../../../../lib/wallet');
+  const actual = await vi.importActual<typeof import('../../../../../lib/wallet')>(
+    '../../../../../lib/wallet',
+  );
   return {
     ...actual,
     isFreighterTransactionSigningAvailable: vi.fn().mockReturnValue(false),
     signFreighterTransaction: vi.fn(),
   };
 });
+
+import {
+  isFreighterTransactionSigningAvailable,
+  signFreighterTransaction,
+} from '../../../../../lib/wallet';
 
 function mockCreateAccount(value: any) {
   createAccountImpl = () => Promise.resolve(value);
@@ -67,125 +77,223 @@ const STATE = {
   expiresIn: 7 * 24 * 60 * 60,
 };
 
+const SUCCESS_ACCOUNT = {
+  accountId: 'acct_1',
+  publicKey: 'GABC',
+  claimUrl: '/claim/1',
+  amount: '10',
+  asset: 'XLM',
+  status: 'pending_payment',
+  expiresAt: new Date().toISOString(),
+  createdAt: new Date().toISOString(),
+};
+
 describe('ConfirmStep error handling', () => {
   beforeEach(() => {
-    mockCreateAccount({
-      accountId: 'acct_1',
-      publicKey: 'GABC',
-      claimUrl: '/claim/1',
-      amount: '10',
-      asset: 'XLM',
-      status: 'pending_payment',
-      expiresAt: new Date().toISOString(),
-      createdAt: new Date().toISOString(),
+    mockCreateAccount(SUCCESS_ACCOUNT);
+    prepareImpl = () => Promise.resolve({ unsignedTxXdr: 'AAAA_UNSIGNED' });
+    vi.mocked(isFreighterTransactionSigningAvailable).mockReturnValue(false);
+    vi.clearAllMocks();
+  });
+
+  it(
+    'shows a user-friendly network error with a retry button',
+    async () => {
+      mockCreateAccountRejects(new TypeError('fetch failed'));
+
+      const user = userEvent.setup({ delay: null });
+      render(<ConfirmStep state={STATE} onBack={vi.fn()} />);
+
+      await user.click(screen.getByRole('button', { name: /confirm & send/i }));
+      await waitFor(() =>
+        expect(screen.getByRole('alert')).toHaveTextContent(/network error/i),
+      );
+
+      expect(screen.getByText(/check your internet connection/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+    },
+    20_000,
+  );
+
+  it(
+    'shows a user-friendly insufficient funds error without a retry button',
+    async () => {
+      mockCreateAccountRejects(
+        new BridgeletApiError(
+          { error: { code: 'INSUFFICIENT_BALANCE', message: 'No funds' } },
+          402,
+        ),
+      );
+
+      const user = userEvent.setup({ delay: null });
+      render(<ConfirmStep state={STATE} onBack={vi.fn()} />);
+
+      await user.click(screen.getByRole('button', { name: /confirm & send/i }));
+      await waitFor(() =>
+        expect(screen.getByRole('alert')).toHaveTextContent(/doesn.t have enough funds/i),
+      );
+
+      expect(screen.queryByRole('button', { name: /try again/i })).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /confirm & send/i })).toBeInTheDocument();
+    },
+    20_000,
+  );
+
+  it(
+    'shows a user-friendly Stellar creation failure with retry',
+    async () => {
+      mockCreateAccountRejects(
+        new BridgeletApiError({ error: { code: 'STELLAR_ERROR', message: 'tx failed' } }, 500),
+      );
+
+      const user = userEvent.setup({ delay: null });
+      render(<ConfirmStep state={STATE} onBack={vi.fn()} />);
+
+      await user.click(screen.getByRole('button', { name: /confirm & send/i }));
+      await waitFor(() =>
+        expect(screen.getByRole('alert')).toHaveTextContent(
+          /create the payment on the stellar network/i,
+        ),
+      );
+
+      expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+    },
+    20_000,
+  );
+
+  it(
+    'increments retry count and limits to MAX_RETRIES',
+    async () => {
+      mockCreateAccountRejects(new TypeError('fetch failed'));
+
+      const user = userEvent.setup({ delay: null });
+      render(<ConfirmStep state={STATE} onBack={vi.fn()} />);
+
+      await user.click(screen.getByRole('button', { name: /confirm & send/i }));
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument(),
+      );
+
+      let tryAgainBtn = screen.getByRole('button', { name: /try again/i });
+      expect(tryAgainBtn).toHaveTextContent(/2 left/);
+
+      await user.click(tryAgainBtn);
+      await waitFor(() => {
+        tryAgainBtn = screen.getByRole('button', { name: /try again/i });
+        expect(tryAgainBtn).toHaveTextContent(/1 left/);
+      });
+
+      await user.click(tryAgainBtn);
+      await waitFor(() => {
+        expect(screen.queryByRole('button', { name: /try again/i })).not.toBeInTheDocument();
+      });
+    },
+    30_000,
+  );
+
+  it(
+    'shows contact support after max retries',
+    async () => {
+      mockCreateAccountRejects(new TypeError('fetch failed'));
+
+      const user = userEvent.setup({ delay: null });
+      render(<ConfirmStep state={STATE} onBack={vi.fn()} />);
+
+      await user.click(screen.getByRole('button', { name: /confirm & send/i }));
+      for (let i = 0; i < 2; i++) {
+        await waitFor(() =>
+          expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument(),
+        );
+        await user.click(screen.getByRole('button', { name: /try again/i }));
+      }
+
+      await waitFor(() => expect(screen.getByText(/contact support/i)).toBeInTheDocument());
+    },
+    30_000,
+  );
+
+  it(
+    'keeps the Back button functional on error',
+    async () => {
+      const onBack = vi.fn();
+      mockCreateAccountRejects(new TypeError('fetch failed'));
+
+      const user = userEvent.setup({ delay: null });
+      render(<ConfirmStep state={STATE} onBack={onBack} />);
+
+      await user.click(screen.getByRole('button', { name: /confirm & send/i }));
+      await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+
+      await user.click(screen.getByRole('button', { name: /back/i }));
+      expect(onBack).toHaveBeenCalledTimes(1);
+    },
+    20_000,
+  );
+});
+
+describe('ConfirmStep Freighter sender signing', () => {
+  beforeEach(() => {
+    mockCreateAccount(SUCCESS_ACCOUNT);
+    prepareImpl = () => Promise.resolve({ unsignedTxXdr: 'AAAA_UNSIGNED' });
+    vi.mocked(isFreighterTransactionSigningAvailable).mockReturnValue(true);
+    vi.mocked(signFreighterTransaction).mockResolvedValue({
+      signedTxXdr: 'AAAA_SIGNED',
+      signerAddress: STATE.publicKey,
+      networkPassphrase: 'Test SDF Network ; September 2015',
     });
     vi.clearAllMocks();
   });
 
-  it('shows a user-friendly network error with a retry button', async () => {
-    mockCreateAccountRejects(new TypeError('fetch failed'));
+  it(
+    'signs with Freighter and reports client-side signing on success',
+    async () => {
+      const user = userEvent.setup({ delay: null });
+      render(<ConfirmStep state={STATE} onBack={vi.fn()} />);
 
-    const user = userEvent.setup();
-    render(<ConfirmStep state={STATE} onBack={vi.fn()} />);
+      await user.click(screen.getByRole('button', { name: /confirm & send/i }));
 
-    await user.click(screen.getByRole('button', { name: /confirm & send/i }));
-    await waitFor(() =>
-      expect(screen.getByRole('alert')).toHaveTextContent(/network error/i),
-    );
+      await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent(/payment sent/i));
+      expect(signFreighterTransaction).toHaveBeenCalledWith('AAAA_UNSIGNED');
+      expect(
+        screen.getByText(/authorised with freighter client-side signing/i),
+      ).toBeInTheDocument();
+    },
+    20_000,
+  );
 
-    expect(screen.getByText(/check your internet connection/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
-  });
+  it(
+    'falls back to backend signing when prepare is unavailable',
+    async () => {
+      prepareImpl = () => Promise.reject(new BridgeletApiError({ message: 'missing' }, 404));
 
-  it('shows a user-friendly insufficient funds error without a retry button', async () => {
-    mockCreateAccountRejects(
-      new BridgeletApiError(
-        { error: { code: 'INSUFFICIENT_BALANCE', message: 'No funds' } },
-        402,
-      ),
-    );
+      const user = userEvent.setup({ delay: null });
+      render(<ConfirmStep state={STATE} onBack={vi.fn()} />);
 
-    const user = userEvent.setup();
-    render(<ConfirmStep state={STATE} onBack={vi.fn()} />);
+      await user.click(screen.getByRole('button', { name: /confirm & send/i }));
 
-    await user.click(screen.getByRole('button', { name: /confirm & send/i }));
-    await waitFor(() =>
-      expect(screen.getByRole('alert')).toHaveTextContent(/doesn.t have enough funds/i),
-    );
+      await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent(/payment sent/i));
+      expect(signFreighterTransaction).not.toHaveBeenCalled();
+      expect(
+        screen.queryByText(/authorised with freighter client-side signing/i),
+      ).not.toBeInTheDocument();
+    },
+    20_000,
+  );
 
-    expect(screen.queryByRole('button', { name: /try again/i })).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /confirm & send/i })).toBeInTheDocument();
-  });
+  it(
+    'surfaces Freighter rejection without silently falling back',
+    async () => {
+      vi.mocked(signFreighterTransaction).mockRejectedValue(new Error('User rejected request'));
 
-  it('shows a user-friendly Stellar creation failure with retry', async () => {
-    mockCreateAccountRejects(
-      new BridgeletApiError(
-        { error: { code: 'STELLAR_ERROR', message: 'tx failed' } },
-        500,
-      ),
-    );
+      const user = userEvent.setup({ delay: null });
+      render(<ConfirmStep state={STATE} onBack={vi.fn()} />);
 
-    const user = userEvent.setup();
-    render(<ConfirmStep state={STATE} onBack={vi.fn()} />);
+      await user.click(screen.getByRole('button', { name: /confirm & send/i }));
 
-    await user.click(screen.getByRole('button', { name: /confirm & send/i }));
-    await waitFor(() =>
-      expect(screen.getByRole('alert')).toHaveTextContent(/create the payment on the stellar network/i),
-    );
-
-    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
-  });
-
-  it('increments retry count and limits to MAX_RETRIES', async () => {
-    mockCreateAccountRejects(new TypeError('fetch failed'));
-
-    const user = userEvent.setup();
-    render(<ConfirmStep state={STATE} onBack={vi.fn()} />);
-
-    await user.click(screen.getByRole('button', { name: /confirm & send/i }));
-    await waitFor(() => expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument());
-
-    let tryAgainBtn = screen.getByRole('button', { name: /try again/i });
-    expect(tryAgainBtn).toHaveTextContent(/2 left/);
-
-    await user.click(tryAgainBtn);
-    await waitFor(() => {
-      tryAgainBtn = screen.getByRole('button', { name: /try again/i });
-      expect(tryAgainBtn).toHaveTextContent(/1 left/);
-    });
-
-    await user.click(tryAgainBtn);
-    await waitFor(() => {
-      expect(screen.queryByRole('button', { name: /try again/i })).not.toBeInTheDocument();
-    });
-  });
-
-  it('shows contact support after max retries', async () => {
-    mockCreateAccountRejects(new TypeError('fetch failed'));
-
-    const user = userEvent.setup();
-    render(<ConfirmStep state={STATE} onBack={vi.fn()} />);
-
-    await user.click(screen.getByRole('button', { name: /confirm & send/i }));
-    for (let i = 0; i < 2; i++) {
-      await waitFor(() => expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument());
-      await user.click(screen.getByRole('button', { name: /try again/i }));
-    }
-
-    await waitFor(() => expect(screen.getByText(/contact support/i)).toBeInTheDocument());
-  });
-
-  it('keeps the Back button functional on error', async () => {
-    const onBack = vi.fn();
-    mockCreateAccountRejects(new TypeError('fetch failed'));
-
-    const user = userEvent.setup();
-    render(<ConfirmStep state={STATE} onBack={onBack} />);
-
-    await user.click(screen.getByRole('button', { name: /confirm & send/i }));
-    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
-
-    await user.click(screen.getByRole('button', { name: /back/i }));
-    expect(onBack).toHaveBeenCalledTimes(1);
-  });
+      await waitFor(() =>
+        expect(screen.getByRole('alert')).toHaveTextContent(/freighter signing was cancelled/i),
+      );
+    },
+    20_000,
+  );
 });


### PR DESCRIPTION
## Summary
- Add the missing `POST /api/accounts/prepare` Next.js proxy route so the Freighter sender-signing experiment can actually obtain an unsigned transaction XDR (previously the client called an endpoint that did not exist, so the flow always silently fell back to backend signing)
- Extract the accounts upstream-proxy logic into a shared `_proxy.ts` used by both `/api/accounts` and `/api/accounts/prepare`
- Add `lib/freighter-sender-signing.ts`: orchestration for the experiment with a `NEXT_PUBLIC_ENABLE_FREIGHTER_SENDER_SIGNING` feature flag, a signer-vs-funding-source mismatch check, and explicit user-rejection handling (cancelling the Freighter prompt surfaces an error instead of silently signing on the backend)
- Rework the send confirm step to use the orchestration module, with progress states ("Preparing transaction…", "Waiting for Freighter…") and a success note when client-side signing was used
- Add unit tests for the signing orchestration and Freighter paths of the confirm step; fix flaky ClaimStatusCard test timeouts
- Update the experiment doc, README docs table, and `.env.example`

## Test plan
- [x] `npm test` — Freighter signing module (9 tests), confirm-step (9 tests incl. 3 Freighter cases), ClaimStatusCard (21 tests) all pass
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors
- [ ] Manual send flow with Freighter installed: prepare → sign → submit with `signingMode: "freighter-client"`
- [ ] Manual send flow without prepare endpoint upstream: falls back to backend signing and still returns a claim URL

Closes #146
