### PR TITLE
docs: postmortems for sender auth, wallet persistence, wallet types, analytics spec

### DIFF
--- a/bridgelet-product-audit/postmortems/analytics-spec-vs-implementation-unverified.md
+++ b/bridgelet-product-audit/postmortems/analytics-spec-vs-implementation-unverified.md
@@ -1,0 +1,138 @@
+# Analytics Spec vs Implementation: Unverified
+
+**Issue:** #320
+**Severity:** Process gap (spec compliance unverified)
+**Date:** 2026-07-28
+
+---
+
+## Summary
+
+`docs/analytics-spec.md` is a 919-line, 28KB document defining event naming
+conventions, payload structures, funnel definitions, and KPIs for Bridgelet.
+However, compliance between this spec and the actual frontend implementation has
+not been verified by tracing each event against the code. This post documents the
+gap and its risks.
+
+## The Spec
+
+`docs/analytics-spec.md` defines:
+
+- **Event naming convention:** `Noun Verb` in Title Case (e.g., `Payment
+  Created`, `Claim Link Copied`).
+- **Standard payload structure:** Common fields across all events.
+- **Sender journey events:** From wallet connection through payment creation.
+- **Recipient journey events:** From claim link opening through sweep
+  confirmation.
+- **Error & edge case events:** Failure paths and boundary conditions.
+- **Conversion funnel definitions:** Step-by-step funnel from landing to
+  settlement.
+- **Business metrics & KPI definitions:** Derived metrics and how they are
+  calculated.
+
+The spec is well-structured and internally consistent. It explicitly scopes
+itself as defining *what* to track and *how to structure it*, not implementing
+any tracking code.
+
+## The Verification Gap
+
+During this audit, the spec was reviewed at a high level — checking naming
+conventions, payload structure, funnel logic, and the critical distinction
+between intent-based events and on-chain confirmation events. That review
+confirmed the spec is internally sound.
+
+**What was not done:** A systematic trace of every defined event against the
+actual frontend code to verify:
+
+1. Does each event name appear in `frontend/` source?
+2. Does each event fire at the point the spec says it fires?
+3. Does each payload field get populated with the value the spec specifies?
+4. Are the funnel step boundaries correctly implemented?
+5. Do the KPI formulas in the spec match any dashboard or query code?
+
+This verification was out of scope for the current audit pass, but the gap
+should be acknowledged.
+
+## The Naming Trap
+
+The most concrete risk identified during the high-level review is documented in
+`integration-notes/analytics-events-vs-onchain-outcomes.md`: the event named
+`Payment Confirmed` fires when the user *confirms* (signs the transaction), not
+when the chain *confirms* (transaction succeeds on-chain).
+
+| Event | Fires when | On-chain confirmed? |
+|-------|-----------|:-------------------:|
+| `Payment Confirmed` | User clicks "Confirm & Pay" and signs | **No** |
+| `Payment Created` | Transaction succeeds on-chain | **Yes** |
+| `Payment Creation Failed` | Blockchain transaction fails after signing | **Yes** (negative) |
+| `Claim Submitted` | Recipient submits the claim | **No** |
+| `Claim Succeeded` | Sweep transaction confirmed on-chain | **Yes** |
+| `Claim Failed` | Sweep fails after recipient confirmed | **Yes** (negative) |
+
+Anyone reading a dashboard without the spec in hand will almost certainly read
+"Payment Confirmed" as settlement. It is not. The funnel section makes the
+distinction load-bearing: step 5 measures "% who sign" and step 6 measures
+"% confirmed → on-chain success." The gap between those steps *is* the on-chain
+failure rate.
+
+## Spec Drift Risk
+
+Without periodic verification, the spec and implementation will inevitably
+diverge. Common drift scenarios:
+
+- **Events added to code but not to spec.** A developer adds a tracking call for
+  a new UI feature but doesn't update `analytics-spec.md`. The event is invisible
+  to anyone relying on the spec for dashboard design.
+- **Events renamed in code but not in spec.** A refactor renames
+  `Payment Created` to `Payment Settled` in the frontend but the spec still
+  says `Payment Created`. Dashboard queries keyed on the spec name break
+  silently.
+- **Payload fields changed.** A new optional field is added to an event payload
+  in code but the spec's payload structure table is not updated. Downstream
+  consumers (data pipelines, dashboards) don't know the field exists.
+- **Events removed from code.** An event is deprecated in the frontend but still
+  listed in the spec. Dashboards that reference it show flat zeros.
+
+None of these are hypothetical — they are the standard failure mode of any spec
+that is not mechanically checked against its implementation.
+
+## What Verification Would Look Like
+
+A proper compliance check would:
+
+1. Extract every event name string from `frontend/` source (grep for the naming
+   pattern).
+2. Extract every event name defined in `analytics-spec.md`.
+3. Diff the two lists to find events in the spec but not in code (orphaned spec
+   entries) and events in code but not in the spec (undocumented events).
+4. For each matched event, verify the payload fields by tracing the tracking
+   call through to its data source.
+5. Verify funnel step ordering matches the actual user flow in the UI.
+
+This could be partially automated but requires human judgment for step 4
+(whether a payload field is *correctly* populated, not just present).
+
+## Recommendations
+
+- **Immediate:** Add a note to `analytics-spec.md` stating that implementation
+  compliance has not been verified, so readers treat it as a design document
+  rather than a source of truth.
+- **Short-term:** Perform the event-name diff (steps 1–3 above) as a lightweight
+  compliance check. This is largely automatable.
+- **Medium-term:** Establish a process for keeping the spec in sync — either
+  require spec updates with every tracking PR, or add a CI check that extracts
+  event names from code and compares them to the spec.
+- **Ongoing:** The `Payment Confirmed` naming issue should be resolved — either
+  rename the event to `Payment Signed` (matching its actual semantics) or add a
+   prominent note to the dashboard layer that `Payment Confirmed` ≠ on-chain
+   settlement.
+
+## Related Documents
+
+- [`docs/analytics-spec.md`](../../docs/analytics-spec.md) — The full 919-line
+  event tracking specification
+- [`integration-notes/analytics-events-vs-onchain-outcomes.md`](../integration-notes/analytics-events-vs-onchain-outcomes.md)
+  — The `Payment Confirmed` naming trap and on-chain vs intent distinction
+- [`postmortems/sender-auth-relies-on-transaction-signing-not-session.md`](./sender-auth-relies-on-transaction-signing-not-session.md)
+  — Auth model that determines how sender identity is established (affects
+  analytics payload for sender-identifying events)

--- a/bridgelet-product-audit/postmortems/connected-wallet-persistence-scope.md
+++ b/bridgelet-product-audit/postmortems/connected-wallet-persistence-scope.md
@@ -1,0 +1,135 @@
+# Connected Wallet Persistence Scope
+
+**Issue:** #318
+**Severity:** Design observation (scope clarification)
+**Date:** 2026-07-28
+
+---
+
+## Summary
+
+`persistWallet()` in `frontend/lib/wallet.ts` stores exactly two fields —
+`publicKey` and `type` — in `localStorage`. This post documents what that
+persistence does and does not protect against, and clarifies that persistence is
+a UI convenience, not a security boundary.
+
+## What Is Persisted
+
+The storage key is `bridgelet_wallet` and the shape is:
+
+```ts
+interface ConnectedWallet {
+  publicKey: string;   // e.g. "G..."
+  type: WalletType;    // 'freighter' | 'lobstr' | 'generated'
+}
+```
+
+Written by `persistWallet()` at `frontend/lib/wallet.ts:29`:
+
+```ts
+export function persistWallet(wallet: ConnectedWallet): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(wallet));
+}
+```
+
+Read back by `loadPersistedWallet()` at `frontend/lib/wallet.ts:34`, which
+returns `null` on any parse failure or missing key. Cleared by
+`clearPersistedWallet()` at `frontend/lib/wallet.ts:44`.
+
+## What Is Not Persisted
+
+**No secret key material is written to `localStorage` by this path.**
+
+The `ConnectedWallet` type has no field for a secret key. Even in the
+`generated` wallet path — where `generateNewWallet()` returns a `secretKey`
+alongside the wallet — `persistWallet()` never receives the secret. It only
+receives `{ publicKey, type }`.
+
+This means:
+
+- A `freighter`-type persisted wallet records which Freighter account was
+  connected, but signing still requires the Freighter extension.
+- A `lobstr`-type persisted wallet records a public key, but there is no
+  signing capability stored.
+- A `generated`-type persisted wallet records a public key, but the secret key
+  (if it was ever returned) is not in `localStorage`.
+
+## Shared Computer Scenario
+
+On a shared or public computer, persisting the public key means the **next
+browser session will show the previously-connected wallet as "connected"** in
+the UI. This is because `loadPersistedWallet()` runs on page load and returns
+the stored `{ publicKey, type }`.
+
+However:
+
+- The UI showing "connected" does not grant signing capability. A Freighter
+  connection still requires the Freighter extension to approve the transaction.
+- For a `generated` wallet, the public key display is cosmetic — without the
+  secret key, no transaction can be signed.
+- For a `lobstr` wallet, the public key is display-only — there is no signing
+  path at all.
+
+**Bottom line:** The persisted public key is a UX hint, not an authorization
+token. It answers "which account did I last use?" — not "can I act on behalf of
+this account?"
+
+## Clearing Browser Data
+
+Clearing `localStorage` (or just the `bridgelet_wallet` key) removes the public
+key association entirely. The user sees a disconnected state with no error
+explaining why.
+
+`loadPersistedWallet()` handles this gracefully — it returns `null` and the UI
+shows the connect button again. But the silent degradation is worth noting: a
+user who clears browser data may be confused about why their wallet "disappeared"
+without an error message.
+
+## The Unchecked Cast
+
+`loadPersistedWallet()` uses an unchecked type assertion:
+
+```ts
+return JSON.parse(raw) as ConnectedWallet;
+```
+
+A well-formed JSON value of the wrong shape (e.g., `{ "foo": "bar" }`) will be
+returned as-is rather than rejected. This is unlikely in practice since only
+`persistWallet()` writes to this key, but it is a theoretical integrity gap if
+the storage is tampered with (e.g., by a browser extension or shared profile
+sync).
+
+## Persistence Is Not a Security Boundary
+
+The key takeaway: `persistWallet()` provides **UI convenience** (surviving page
+reloads), not **security** (authorizing actions). The actual security boundary
+lives in:
+
+- The Freighter extension (for `freighter` type) — which gates signing behind
+  its own approval popup.
+- The server-side signature verification (for all types) — which checks that the
+  transaction was signed by the claimed public key.
+
+Persisting the public key in `localStorage` does not weaken or strengthen the
+security model. It is orthogonal to it.
+
+## Recommendations
+
+- Document the `bridgelet_wallet` storage key in the security model so auditors
+  know it exists and what it contains.
+- Consider adding a brief user-facing note when a wallet is shown as "connected"
+  from persistence — e.g., a subtle indicator that reconnection was automatic
+  rather than explicitly approved in this session.
+- The unchecked cast in `loadPersistedWallet()` is low-risk but should be
+  validated if the storage key is ever written to by other code paths.
+
+## Related Documents
+
+- [`glossary/connected-wallet-persistence.md`](../glossary/connected-wallet-persistence.md)
+  — The canonical glossary entry for this persistence mechanism
+- [`frontend/lib/wallet.ts`](../../frontend/lib/wallet.ts) — `persistWallet()`,
+  `loadPersistedWallet()`, `clearPersistedWallet()` at lines 29, 34, 44
+- [`postmortems/sender-auth-relies-on-transaction-signing-not-session.md`](./sender-auth-relies-on-transaction-signing-not-session.md)
+  — Why there is no session token to persist in the first place
+- [`glossary/wallet-connection-types.md`](../glossary/wallet-connection-types.md)
+  — What each `WalletType` value means in practice

--- a/bridgelet-product-audit/postmortems/sender-auth-relies-on-transaction-signing-not-session.md
+++ b/bridgelet-product-audit/postmortems/sender-auth-relies-on-transaction-signing-not-session.md
@@ -1,0 +1,119 @@
+# Sender Auth Relies on Transaction Signing, Not Session Tokens
+
+**Issue:** #317
+**Severity:** Design observation (not a vulnerability)
+**Date:** 2026-07-28
+
+---
+
+## Summary
+
+The Bridgelet sender authentication model (`/send` page) deliberately issues no
+session token, no JWT, and no cookie. Wallet ownership is proven at
+transaction-signing time — the signature itself is the credential. This post
+documents the design choice, its rationale, and its tradeoffs.
+
+## The Design Choice
+
+`docs/sender-auth-model.md` evaluates three options and selects Option B:
+
+> **No session token or JWT is created. Wallet ownership is proven at
+> transaction-signing time.**
+
+This is stated plainly under "Security Notes":
+
+- No session token or JWT is created.
+- Wallet ownership is proven at transaction-signing time.
+- The public key identifies the sender; the transaction signature is the implicit
+  proof of auth.
+
+The rejection of alternatives is equally explicit:
+
+| Option | Rejected because |
+|--------|-----------------|
+| A — Static `X-API-Key` | Key would leak in the JS bundle when shipped as an env var to the browser. |
+| C — No auth (open send) | Unmitigated spam/abuse risk without rate-limiting. |
+
+## Why This Is Deliberate
+
+The model maps naturally to Stellar's mental model: you own a key, you prove
+ownership by signing. There is no separate auth step because signing *is* the
+auth step.
+
+Concretely:
+
+1. The user clicks "Connect Freighter Wallet" in the `WalletConnect` component
+   (`frontend/components/wallet-connect.tsx`).
+2. Freighter returns the public key via `requestAccess()` / `getAddress()`.
+3. When the sender creates a payment intent, the Bridgelet SDK calls
+   `signFreighterTransaction()` in `frontend/lib/wallet.ts:73`, which delegates
+   to the Freighter extension's `signTransaction` API.
+4. The signed XDR is sent to the server. The server verifies the signature — no
+   token is checked because there is none.
+
+This means there is **no session to manage, no token to refresh, and no
+expiration to enforce**. The auth boundary lives exactly where the money moves.
+
+## Tradeoff: No Session Revocation
+
+The absence of a session token has a direct consequence: **there is no session
+to revoke.**
+
+- If a user disconnects Freighter, the public key is cleared from `localStorage`
+  (via `clearPersistedWallet()` in `frontend/lib/wallet.ts:44`), but that only
+  removes the *UI convenience* of auto-reconnect. It does not prevent the same
+  user from reconnecting and signing immediately.
+- There is no server-side session record, so a server-side "log out" or
+  "revoke token" operation is inapplicable.
+- If a signing key is compromised, the attacker can sign transactions until the
+  Stellar key itself is rotated on-chain — the Bridgelet layer has no kill
+  switch.
+
+This is an acceptable tradeoff for the current scope (a payment link creator),
+but should be revisited if the sender role expands to include account management
+or sensitive configuration.
+
+## The Flip Side: No Session to Steal
+
+The corollary of "no session token" is that there is **no session token to
+steal.** Common session-hijack vectors — cookie theft, token exfiltration from
+`localStorage`, JWT replay — are structurally absent. The attacker needs the
+actual signing key (held inside the Freighter extension or the Stellar SDK
+keypair), not a bearer credential.
+
+For the `generated` wallet path (`generateNewWallet()` at
+`frontend/lib/wallet.ts:127`), the secret key is returned to the caller as a
+plaintext string. If that path is ever wired into a UI, the custody question
+becomes acute — see `integration-notes/generated-wallet-key-custody.md`.
+
+## Implications for Future Work
+
+- **Rate limiting.** Option C was rejected partly because of spam risk. Any
+  sender-side rate limiting must be keyed on the Stellar public key, not on a
+  session identifier. Consider per-key rate limits tied to on-chain account
+  state (e.g., minimum balance, recent transaction count).
+- **Backend integrations.** Option A (static `X-API-Key`) remains viable for
+  server-to-server calls. The sender-auth-model doc explicitly calls this out.
+  Ensure the API key model is documented separately and not conflated with the
+  browser auth model.
+- **Audit trail.** Because there is no session, logging and audit must rely on
+  the public key and the signed transaction XDR. Any logging infrastructure
+  should correlate by `signerAddress`, not by session ID.
+
+## Verdict
+
+This is a sound design for the current product scope. The absence of sessions is
+a feature, not a gap — but the team should be aware that extending the sender
+role beyond "create a payment link" may require revisiting this assumption.
+
+## Related Documents
+
+- [`docs/sender-auth-model.md`](../../docs/sender-auth-model.md) — The decision
+  record for Option B
+- [`glossary/sender-vs-recipient-auth-models.md`](../glossary/sender-vs-recipient-auth-models.md)
+  — How sender auth (wallet-based) differs from recipient auth (claim-token
+  bearer model)
+- [`frontend/lib/wallet.ts`](../../frontend/lib/wallet.ts) — `connectFreighter()`,
+  `signFreighterTransaction()`, `persistWallet()` implementations
+- [`integration-notes/generated-wallet-key-custody.md`](../integration-notes/generated-wallet-key-custody.md)
+  — Key custody concerns for the unused `generated` wallet path

--- a/bridgelet-product-audit/postmortems/three-wallet-types-inconsistent-completeness.md
+++ b/bridgelet-product-audit/postmortems/three-wallet-types-inconsistent-completeness.md
@@ -1,0 +1,149 @@
+# Three Wallet Types with Inconsistent Completeness
+
+**Issue:** #319
+**Severity:** Design inconsistency
+**Date:** 2026-07-28
+
+---
+
+## Summary
+
+The `WalletType` union in `frontend/lib/wallet.ts` defines three values:
+`freighter`, `lobstr`, and `generated`. Each represents a different wallet
+connection approach, but they are at vastly different levels of implementation
+maturity. This post documents the completeness gap and its implications.
+
+## The Three Types
+
+```ts
+export type WalletType = 'freighter' | 'lobstr' | 'generated';
+```
+
+### Completeness Matrix
+
+| Property | `freighter` | `lobstr` | `generated` |
+|----------|:-----------:|:--------:|:-----------:|
+| Connection function exists | ✅ `connectFreighter()` | ✅ `connectLobstr()` | ✅ `generateNewWallet()` |
+| Function does real work | ✅ Calls Freighter API | ❌ Throws sentinel | ✅ Creates keypair |
+| Returns `ConnectedWallet` | ✅ Always | ❌ Never (always throws) | ✅ Always |
+| Transaction signing | ✅ `signFreighterTransaction()` | ❌ No signing path | ❌ No signing path |
+| UI component wired | ✅ `WalletConnect` renders Freighter button | ⚠️ Paste flow referenced but uncaptured | ❌ No UI |
+| Called anywhere in `frontend/` | ✅ Yes | ❌ No callers | ❌ No callers |
+| Documented as working | ✅ | ⚠️ `sender-auth-model.md` says "already wired" | ⚠️ Documented as threat T-15 |
+
+## Freighter: Fully Implemented
+
+`connectFreighter()` at `frontend/lib/wallet.ts:49` is the only wallet type with
+a complete end-to-end flow:
+
+1. Checks `freighter.isConnected()` for extension presence.
+2. Calls `freighter.requestAccess()` to open the approval popup.
+3. Reads the address via `freighter.getAddress()`.
+4. Returns `{ publicKey, type: 'freighter' }`.
+5. Transaction signing via `signFreighterTransaction()` delegates to
+   `freighter.signTransaction()`.
+
+This is the **only** wallet path that actually works in production. The
+`WalletConnect` component (`frontend/components/wallet-connect.tsx`) renders a
+"Connect Freighter Wallet" button that calls this function.
+
+## Generated: Implemented but Unused
+
+`generateNewWallet()` at `frontend/lib/wallet.ts:127` is a complete function
+that:
+
+- Dynamically imports `@stellar/stellar-sdk` (to avoid SSR issues).
+- Calls `Keypair.random()` to create a fresh Stellar keypair.
+- Returns `{ wallet: { publicKey, type: 'generated' }, secretKey }`.
+
+**However, it has zero callers anywhere in `frontend/`.** The function is
+exported, typed, and documented — but nothing invokes it. The `secretKey` is
+returned as a plaintext string to browser JavaScript, raising custody questions
+that are documented in `integration-notes/generated-wallet-key-custody.md` but
+unresolved.
+
+Key open questions for the `generated` path:
+
+- Where does the secret key live after generation?
+- How does the user recover it?
+- What is the key's lifetime in browser memory?
+- How does signing work without Freighter?
+
+These are not answered because no code path reaches `generateNewWallet()`.
+
+## LOBSTR: Partially Implemented (Sentinel Only)
+
+`connectLobstr()` at `frontend/lib/wallet.ts:119` has exactly one behaviour — it
+throws a sentinel:
+
+```ts
+export async function connectLobstr(): Promise<ConnectedWallet> {
+  throw new Error('USE_PASTE_FLOW');
+}
+```
+
+The intent is clear from the comments: the UI should catch this sentinel and
+render a paste-your-public-key step. But the other half never landed:
+
+- `USE_PASTE_FLOW` appears in exactly one place in the entire codebase: the
+  `throw` statement itself.
+- No component, hook, or error boundary catches it.
+- `connectLobstr()` has **no callers** in `frontend/`.
+- `docs/sender-auth-model.md` states LOBSTR "is supported via a paste-your-public-key
+  fallback already wired in `lib/wallet.ts`" — this is half-true in a misleading
+  way.
+
+If a user were somehow routed to the LOBSTR option, they would see the raw
+`USE_PASTE_FLOW` error string, which is meaningless to a non-developer. The
+mitigation is that the failure is currently unreachable because nothing calls
+`connectLobstr()`.
+
+## The Documentation Mismatch
+
+The inconsistency is not just in code — it extends to documentation:
+
+- `sender-auth-model.md` Security Notes claim LOBSTR "is supported via a
+  paste-your-public-key fallback already wired in `lib/wallet.ts`." The function
+  exists, but it implements no paste flow — it implements a *request* for one.
+- `docs/security-model.mdx` logs `generateNewWallet()` as threat T-15, noting
+  the secret handling requires audit. This is accurate but reads as if the flow
+  is live, when it is unused.
+
+A reader of the docs alone would conclude all three wallet types are functional.
+A reader of the code alone would conclude only Freighter works. Neither picture
+is complete without the other.
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact |
+|------|-----------|--------|
+| User hits `USE_PASTE_FLOW` sentinel | Low (no caller) | Medium (confusing error) |
+| `generated` path wired without custody design | Medium (future work) | High (secret key in browser memory) |
+| Docs claim LOBSTR support in user-facing materials | Low (internal docs only) | Low (misleads auditors, not users) |
+
+## Recommendations
+
+- **Immediate:** Update `sender-auth-model.md` to reflect that LOBSTR paste flow
+  is *planned* but not implemented, not "already wired."
+- **Before wiring `generated`:** Resolve the key custody design (storage,
+  transmission, recovery, lifetime) — see `generated-wallet-key-custody.md`.
+- **Before wiring LOBSTR:** Decide whether the paste flow is the right UX or
+  whether a deeplink/QR approach is preferable. If paste, implement the UI
+  handler for `USE_PASTE_FLOW`.
+- **Long-term:** Consider whether the `WalletType` union should include types
+  that are not implemented, or whether they should be introduced only when the
+  corresponding flow is complete.
+
+## Related Documents
+
+- [`glossary/wallet-connection-types.md`](../glossary/wallet-connection-types.md)
+  — Canonical definition of each `WalletType` value
+- [`integration-notes/lobstr-paste-flow-not-implemented.md`](../integration-notes/lobstr-paste-flow-not-implemented.md)
+  — Detailed trace of the `USE_PASTE_FLOW` sentinel and its missing handler
+- [`integration-notes/generated-wallet-key-custody.md`](../integration-notes/generated-wallet-key-custody.md)
+  — Open custody questions for the unused `generated` path
+- [`frontend/lib/wallet.ts`](../../frontend/lib/wallet.ts) — All three connection
+  functions: `connectFreighter()` (line 49), `connectLobstr()` (line 119),
+  `generateNewWallet()` (line 127)
+- [`docs/sender-auth-model.md`](../../docs/sender-auth-model.md) — The decision
+  record that claims LOBSTR support is "already wired"


### PR DESCRIPTION
Closes #317
Closes #318
Closes #319
Closes #320

Adds 4 postmortem articles documenting the sender-auth no-session design, wallet persistence scope, three-wallet-type completeness gaps, and unverified analytics spec compliance.