### PR TITLE
docs: postmortems for FRD overlap, custodial terminology, auth doc gap, claim errors

### DIFF
--- a/bridgelet-product-audit/postmortems/claim-error-message-specificity-unverified.md
+++ b/bridgelet-product-audit/postmortems/claim-error-message-specificity-unverified.md
@@ -1,0 +1,88 @@
+# Issue #324: Whether Claim-Flow Error Messages Preserve Specific On-Chain Failure Reasons
+
+**Status:** Open
+**Severity:** Medium
+**Author:** temiport25
+**Date:** 2026-07-28
+
+## Summary
+
+The `integration-notes/three-repo-error-surface-consistency.md` document reveals that the claim flow across `bridgelet-core`, `bridgelet-sdk`, and `bridgelet` uses a `??` (nullish coalescing) fallback pattern when propagating error messages. This pattern can collapse specific on-chain failure reasons into generic messages by the time they reach the end user. **This behavior was not verified end-to-end** during the product audit.
+
+## Why This Matters
+
+When a claim transaction fails on-chain, the failure reason is often highly specific — insufficient funds, contract revert with a reason string, nonce collision, slippage exceeded, etc. These specific reasons are critical for:
+
+- **User debugging:** End users need to know *why* their claim failed so they can take corrective action (e.g., add funds, retry later, adjust parameters).
+- **Support triage:** Support teams rely on error message specificity to diagnose issues without requiring users to provide transaction hashes and chain-level traces.
+- **Developer debugging:** Integration developers using the SDK need granular errors to build resilient retry and fallback logic.
+- **Monitoring and alerting:** Specific error strings enable meaningful alerting rules (e.g., alert on "nonce collision" but not on "transaction failed").
+
+If the `??` fallback replaces specific messages with generic ones (e.g., "Claim failed" instead of "Claim failed: insufficient balance for protocol fee"), the entire error signaling chain is degraded.
+
+## The `??` Fallback Pattern
+
+The three-repo error surface consistency document identifies a pattern where each layer in the call chain uses nullish coalescing to provide a default error message:
+
+```
+// Hypothetical representation of the pattern at each layer
+const message = error?.reason ?? error?.message ?? "Claim failed";
+```
+
+This means:
+
+1. **bridgelet-core** produces a specific error (e.g., `{ reason: "InsufficientBalance", detail: "protocol fee requires 0.5 XLM, account has 0.1 XLM" }`).
+2. **bridgelet-sdk** receives the error but accesses only `error.message`, which may be undefined for structured errors, and falls back to a generic string.
+3. **bridgelet** (application) receives the SDK error and applies another `??` fallback, further degrading specificity.
+
+Each layer's fallback is individually reasonable (it prevents `undefined` from reaching the user), but the cumulative effect is that specificity is lost at every boundary crossing.
+
+## What Was Not Verified
+
+The audit identified the pattern but did not perform the following:
+
+1. **End-to-end tracing:** No test was run that produced a specific on-chain failure and traced the error message through all three layers to confirm whether specificity was preserved.
+2. **Fallback inventory:** No comprehensive list was made of all places in the codebase where `??` is used for error propagation.
+3. **Structured error contract:** No verification that the three repos agree on a structured error type (with `reason`, `detail`, `code`, etc.) versus relying on plain strings.
+4. **User-facing message audit:** No review of the actual messages displayed to end users in the bridgelet UI for claim failures.
+
+## Risk Assessment
+
+| Factor | Detail |
+|---|---|
+| Likelihood of specificity loss | High — the `??` pattern guarantees fallback when upstream does not set `.message` |
+| Impact on users | Medium — users see generic errors and cannot self-service |
+| Impact on support | Medium — support tickets increase because users cannot diagnose issues |
+| Detection difficulty | Low — an end-to-end test with a deliberate failure would confirm or deny |
+| Remediation effort | Medium — requires establishing a structured error contract and updating each layer |
+
+## Recommended Actions
+
+1. **End-to-end error tracing test.** Write a test that triggers a known on-chain failure (e.g., insufficient balance) and asserts that the specific reason string is visible in the application-layer response or UI.
+2. **Structured error contract.** Define a shared error type across all three repos (e.g., `BridgeletError { code: string; reason: string; detail: string; }`) and require that each layer propagates the full structure, not just a string.
+3. **Audit all `??` fallback sites.** Grep the three repos for `??` patterns in error-handling paths and evaluate each one: does the fallback obscure useful information?
+4. **Layered error messages.** Implement a convention where each layer *wraps* the upstream error rather than replacing it:
+   ```typescript
+   throw new BridgeletError({
+     code: "CLAIM_FAILED",
+     upstream: error,  // preserve the original
+     message: `Claim failed: ${error.reason}`
+   });
+   ```
+5. **User-facing message review.** Audit the bridgelet UI to confirm that claim failure messages shown to users include actionable details.
+6. **Add to CI.** Add a CI check that flags new `??` usage in error-handling code paths for manual review.
+
+## Code / File References
+
+- `bridgelet-product-audit/integration-notes/three-repo-error-surface-consistency.md` — The document that identified the `??` fallback pattern and its impact on error message specificity.
+- `bridgelet-core/src/` — Core claim logic that produces initial error objects.
+- `bridgelet-sdk/src/` — SDK layer that receives and propagates (or degrades) errors.
+- `bridgelet/src/` — Application layer that renders error messages to end users.
+- Specific line numbers and file paths were not captured during the audit; a follow-up grep for `??` in error paths is recommended.
+
+## Related Documents
+
+- `bridgelet-product-audit/integration-notes/three-repo-error-surface-consistency.md` — The source document for this finding. It contains the detailed analysis of how errors flow across the three repos. This postmortem summarizes the finding and adds recommended actions.
+- `bridgelet-product-audit/postmortems/custodial-model-terminology-scope.md` — Another cross-repo consistency issue, focused on terminology rather than error handling.
+- `bridgelet-product-audit/postmortems/org-integration-auth-doc-gap.md` — A documentation gap issue that, like this one, was identified during the same audit cycle.
+- `bridgelet-product-audit/postmortems/frd-and-technical-spec-overlap-unverified.md` — A documentation overlap issue from the same audit.

--- a/bridgelet-product-audit/postmortems/custodial-model-terminology-scope.md
+++ b/bridgelet-product-audit/postmortems/custodial-model-terminology-scope.md
@@ -1,0 +1,86 @@
+# Issue #322: What "Custodial Model" Means Across Three Repos
+
+**Status:** Open
+**Severity:** High
+**Author:** temiport25
+**Date:** 2026-07-28
+
+## Summary
+
+The term **"Custodial Model"** is defined in `docs/GLOSSARY.md` and is used across three repositories — `bridgelet-core`, `bridgelet-sdk`, and `bridgelet` — but each repo implements or refers to it differently. The product audit identified this divergence but was not able to fully reconcile the three implementations into a single coherent definition.
+
+## Why This Matters
+
+A shared glossary term that means different things in different codebases creates:
+
+- **Semantic confusion:** When `bridgelet-core` says "custodial model," developers in `bridgelet-sdk` may interpret it to mean something different. This leads to integration bugs that are hard to diagnose because both sides believe they agree on the term.
+- **Incorrect documentation:** End-user guides that reference "the custodial model" may describe behavior that matches one repo's implementation but not another's.
+- **Onboarding friction:** New contributors reading the glossary first will form an expectation that is violated when they read the actual code.
+- **Audit blind spots:** As this audit demonstrated, term-level divergence can go undetected until cross-repo integration testing surfaces it.
+
+## The Three Implementations
+
+### GLOSSARY.md (Canonical Definition)
+
+`docs/GLOSSARY.md` provides the project-wide definition of "Custodial Model." This is intended to be the single source of truth for the term's meaning. However, the glossary definition is high-level and leaves implementation details to each repo.
+
+### bridgelet-core
+
+`bridgelet-core` implements the custodial model at the protocol level. Key characteristics include:
+
+- Key management and signing logic for custodial wallets.
+- On-chain transaction construction and submission.
+- Account state tracking.
+
+The core implementation may enforce constraints (e.g., key rotation policies, transaction limits) that are considered part of the custodial model but are not reflected in the other repos.
+
+### bridgelet-sdk
+
+`bridgelet-sdk` exposes the custodial model as a developer-facing API. The SDK abstracts away core-level details and presents a simplified interface. This abstraction may:
+
+- Hide certain custodial behaviors (e.g., key rotation) behind convenience methods.
+- Use different terminology for the same operations (e.g., "sign" vs. "authorize").
+- Impose additional constraints or validations not present in core.
+
+### bridgelet (Application Layer)
+
+The `bridgelet` repo is the end-user-facing application. It consumes `bridgelet-sdk` and presents custodial model features through UI and API endpoints. The application layer may:
+
+- Bundle multiple custodial operations into single user-facing actions.
+- Add application-specific business rules on top of the SDK.
+- Use UI labels that do not map one-to-one to SDK or core concepts.
+
+## Risk Assessment
+
+| Factor | Detail |
+|---|---|
+| Likelihood of divergence | Confirmed — the audit found differences across all three repos |
+| Impact of divergence | High — incorrect assumptions about custodial behavior can lead to security-relevant bugs |
+| Detection difficulty | Medium — requires cross-repo code review and integration testing |
+| Remediation effort | Medium — requires a reconciliation workshop and glossary update |
+
+## Recommended Actions
+
+1. **Reconciliation session.** Bring together maintainers from `bridgelet-core`, `bridgelet-sdk`, and `bridgelet` to align on a single, precise definition of "Custodial Model" that covers all three layers.
+2. **Layered glossary.** Extend `docs/GLOSSARY.md` to include per-layer descriptions:
+   - Protocol-level (core): what the custodial model means for on-chain operations.
+   - API-level (SDK): what the custodial model exposes to developers.
+   - Application-level (bridgelet): what the custodial model means to end users.
+3. **Cross-reference from each repo.** Each repo's README or local glossary should reference the canonical definition and explicitly state how its implementation relates to it.
+4. **Integration tests.** Add tests that verify custodial model behavior is consistent across all three layers (e.g., a key rotation initiated via the SDK is correctly reflected in core and visible in the application).
+5. **Audit checklist update.** Future audits should verify that glossary terms have consistent implementations across all repos.
+
+## Code / File References
+
+- `docs/GLOSSARY.md` — Canonical definition of "Custodial Model" (first 60 lines reviewed during audit).
+- `bridgelet-core/src/` — Core implementation of custodial model (specific files not enumerated in this audit).
+- `bridgelet-sdk/src/` — SDK abstraction of custodial model.
+- `bridgelet/src/` — Application-layer implementation.
+- `bridgelet-product-audit/glossary/custodial-model-in-practice.md` — Detailed notes on how the custodial model is implemented across repos (see Related Documents below).
+
+## Related Documents
+
+- `bridgelet-product-audit/glossary/custodial-model-in-practice.md` — Companion document with a detailed breakdown of custodial model implementation differences across the three repos. This postmortem summarizes the findings; the glossary document provides the full analysis.
+- `bridgelet-product-audit/postmortems/frd-and-technical-spec-overlap-unverified.md` — Another instance of cross-document consistency issues within the bridgelet project.
+- `bridgelet-product-audit/postmortems/org-integration-auth-doc-gap.md` — Illustrates the broader pattern of documentation gaps in the project.
+- `bridgelet-product-audit/postmortems/claim-error-message-specificity-unverified.md` — Cross-repo consistency concern in error handling.

--- a/bridgelet-product-audit/postmortems/frd-and-technical-spec-overlap-unverified.md
+++ b/bridgelet-product-audit/postmortems/frd-and-technical-spec-overlap-unverified.md
@@ -1,0 +1,90 @@
+# Issue #321: Potential Overlap Between Bridgelet FRD UI/UX and Frontend Technical Spec Unverified
+
+**Status:** Open
+**Severity:** Medium
+**Author:** temiport25
+**Date:** 2026-07-28
+
+## Summary
+
+During the bridgelet product audit, two documents were identified by name as potentially covering overlapping scope for the bridgelet frontend:
+
+1. `bridgelet-frd-ui-ux.md` — appears to be a functional requirements document (FRD) focused on UI/UX.
+2. `FRONTEND_TECHNICAL_SPEC.md` — appears to be a technical specification for the frontend.
+
+These documents were **not compared or cross-referenced** during the audit. Their relationship, scope boundaries, and degree of overlap remain unverified. This postmortem records the finding as an open question for follow-up.
+
+## Why This Matters
+
+When two documents appear to address the same subsystem (bridgelet frontend), several risks emerge:
+
+- **Drift:** Without a clear ownership boundary, each document can evolve independently and contradict the other. A developer reading only one may implement features that conflict with the other's requirements.
+- **Ambiguity for new contributors:** Onboarding engineers will not know which document is authoritative for a given frontend behavior.
+- **Audit gap:** The product audit did not confirm whether these documents are complementary (one high-level, one detailed), redundant (saying the same thing), or contradictory (saying different things).
+- **Maintenance overhead:** Two documents covering the same surface area means twice the update burden when requirements change.
+
+## What Was Not Verified
+
+The following questions remain open:
+
+1. Do `bridgelet-frd-ui-ux.md` and `FRONTEND_TECHNICAL_SPEC.md` cover the same features, or does each own a distinct subset?
+2. Is one intended as a superset of the other?
+3. Which document is considered the source of truth when they conflict?
+4. Are there sections in one document that have no counterpart in the other?
+5. Has either document been updated recently to incorporate the other's content?
+6. Do either document reference the other explicitly, or are they completely unaware of each other?
+7. Have changes been made in one document that were not reflected in the other?
+8. Is there a versioning or last-updated timestamp on either document that indicates recency?
+
+## Possible Relationships
+
+Based on naming conventions alone, several structural relationships are possible:
+
+- **FRD is a superset of the technical spec.** The FRD covers all product requirements including non-frontend concerns, while the technical spec narrows to frontend implementation details.
+- **Technical spec is a superset of the FRD.** The technical spec includes both product requirements and implementation guidance, making the FRD redundant.
+- **Complementary non-overlapping documents.** The FRD covers what the frontend should do (user stories, acceptance criteria), while the technical spec covers how it should be built (architecture, component structure, state management).
+- **Divergent duplicates.** Both documents describe the same scope but were written by different authors at different times, leading to contradictions.
+
+Each scenario demands a different remediation. Without reading both documents, the audit cannot determine which scenario applies.
+
+## Evidence from the Audit
+
+The audit identified these documents through filename pattern matching during the documentation inventory phase. The following observations were made:
+
+- Both files exist in the repository tree and are not symlinks or aliases.
+- Neither file appears to import, include, or link to the other based on filename analysis alone.
+- The audit did not open either file to verify contents, making this a pure identification finding rather than a content analysis finding.
+- No issue or PR was found that tracks the relationship between these two documents.
+
+This finding is recorded as an open question to be resolved in a follow-up pass.
+
+## Risk Assessment
+
+| Factor | Detail |
+|---|---|
+| Likelihood of drift | High — two living documents with no enforced synchronization |
+| Impact of drift | Medium — frontend devs may implement against stale or conflicting specs |
+| Detection difficulty | Low — a side-by-side comparison would surface issues quickly |
+| Remediation effort | Low — a single reconciliation pass, then establishing ownership rules |
+
+## Recommended Actions
+
+1. **Side-by-side comparison.** Read both documents in full and map section-by-section which topics each covers. Identify overlaps, gaps, and contradictions. Produce a matrix showing which topics appear in which document.
+2. **Designate an authority.** Decide which document is the canonical source for frontend requirements and which, if any, is a derived or supplementary view.
+3. **Add cross-references.** If both documents are kept, each should contain explicit pointers to the other explaining the relationship (e.g., "This FRD covers product requirements; see `FRONTEND_TECHNICAL_SPEC.md` for implementation details").
+4. **Stale-document policy.** If one document is found to be outdated, either archive it or bring it up to date and add a maintenance cadence. Consider adding a `last-reviewed` field to both documents.
+5. **Update the audit checklist.** Future audits should explicitly verify whether overlapping documents have been reconciled before marking the documentation domain as complete.
+
+## Code / File References
+
+- `bridgelet-frd-ui-ux.md` — FRD for bridgelet UI/UX (location: unconfirmed, likely under `docs/` or `bridgelet/docs/`).
+- `FRONTEND_TECHNICAL_SPEC.md` — Frontend technical spec (location: unconfirmed).
+- No commit hashes or line-level references available since document contents were not read during the audit.
+- The audit tooling did not flag these two documents as duplicates or related; the identification was manual based on filename heuristics.
+- If these documents live in different directories or repos, the risk of drift increases further since there is no single directory listing that surfaces both.
+
+## Related Documents
+
+- `bridgelet-product-audit/postmortems/custodial-model-terminology-scope.md` — Another instance where cross-document terminology needs reconciliation.
+- `bridgelet-product-audit/postmortems/org-integration-auth-doc-gap.md` — A case where a documented need for a separate guide was never fulfilled, illustrating the broader pattern of documentation gaps.
+- `bridgelet-product-audit/postmortems/claim-error-message-specificity-unverified.md` — A related case where cross-repo consistency was not verified end-to-end.

--- a/bridgelet-product-audit/postmortems/org-integration-auth-doc-gap.md
+++ b/bridgelet-product-audit/postmortems/org-integration-auth-doc-gap.md
@@ -1,0 +1,84 @@
+# Issue #323: Option A (API Key) Auth Path Lacking Its Own Integration Guide
+
+**Status:** Open
+**Severity:** Medium
+**Author:** temiport25
+**Date:** 2026-07-28
+
+## Summary
+
+The `docs/sender-auth-model.md` document explicitly describes two authentication paths — Option A (API key based) and Option B (OAuth / token based) — and states that Option A should be "documented separately in an integration guide." As of this audit, **that integration guide does not exist.** The auth model document itself is the only authoritative source for Option A, and it was written as a design document, not a step-by-step integration guide.
+
+## Why This Matters
+
+An authentication path without its own integration guide creates several problems:
+
+- **Developer friction:** Integrators choosing the API key path have no dedicated walkthrough. They must reverse-engineer the expected behavior from `sender-auth-model.md`, which was written for internal design discussion, not external consumption.
+- **Inconsistent implementations:** Without a guide specifying exact header formats, error codes, rate limits, and retry behavior, each integration team will make different assumptions.
+- **Security risk:** API key authentication has specific security requirements (key rotation, scoping, secure storage). A missing guide means these requirements are not surfaced to integrators at the point of need.
+- **Broken promise in documentation:** The auth model document promises a separate guide. When integrators follow the reference and find nothing, it undermines trust in the rest of the documentation.
+
+## Current State
+
+### What `sender-auth-model.md` Covers
+
+The auth model document describes:
+
+- The two authentication options (A and B) and when each applies.
+- The general flow for API key authentication under Option A.
+- The note that Option A requires a separate integration guide.
+
+### What Is Missing
+
+The following content would be expected in an Option A integration guide but does not exist anywhere:
+
+| Topic | Status |
+|---|---|
+| Step-by-step setup instructions | Missing |
+| API key format and header specification | Partially covered in auth model, not in guide form |
+| Key rotation procedure | Not documented |
+| Rate limiting behavior for API key requests | Not documented |
+| Error codes and troubleshooting | Not documented |
+| Scoping and permissions model | Not documented |
+- Example request/response pairs | Not documented |
+| Testing and sandbox instructions | Not documented |
+
+## Risk Assessment
+
+| Factor | Detail |
+|---|---|
+| Likelihood of impact | High — any integrator choosing Option A will hit this gap |
+| Impact of gap | Medium — developers can still reverse-engineer from source, but at significant cost |
+| Detection difficulty | Low — the auth model document explicitly calls out the gap |
+| Remediation effort | Medium — requires authoring a standalone guide from existing code and design docs |
+
+## Downstream Impact
+
+The missing guide does not exist in a vacuum. Its absence ripples into several areas:
+
+- **Partner integrations:** Third-party teams building integrations against the API key path have no reference. They must either ask the bridgelet team directly or reverse-engineer the auth flow from source code.
+- **SDK consumers:** Developers using `bridgelet-sdk` may encounter API key auth as a configuration option but have no documentation on how to set it up correctly.
+- **Internal consistency:** The `sender-auth-model.md` file is referenced by multiple internal documents. Those references assume the guide exists, creating a chain of broken dependencies.
+- **Compliance and security reviews:** Auditors reviewing the auth model will flag the missing guide as a documentation control gap, especially for API key rotation and scoping.
+
+## Recommended Actions
+
+1. **Create the guide.** Author `docs/integration-guide-api-key-auth.md` (or similar) covering all topics listed in the table above. The auth model document itself provides the design rationale; the new guide should provide the operational details.
+2. **Cross-reference bidirectionally.** Update `sender-auth-model.md` to link to the new guide where it currently says "documented separately." The new guide should also link back to the auth model for design context.
+3. **Review with a sample integration.** Before publishing, walk through the guide with a real or simulated integration to verify completeness and accuracy.
+4. **Add to audit scope.** Future audits should verify that referenced-but-not-yet-created documents have been delivered.
+5. **Consider Option B parity.** Check whether Option B (OAuth / token) also has a standalone guide. If not, the same gap applies and should be addressed in the same effort.
+6. **Establish a document-tracker convention.** Any future design document that promises a follow-up guide should create a tracking issue or placeholder file so that the gap is visible to project management.
+
+## Code / File References
+
+- `docs/sender-auth-model.md` — The auth model document that defines both Option A and Option B, and that explicitly calls for a separate Option A guide.
+- `bridgelet/src/auth/` or `bridgelet-core/src/auth/` — Likely location of the API key authentication implementation (exact path not confirmed during audit).
+- `bridgelet-product-audit/glossary/org-integration-api-key-model.md` — Detailed notes on the API key authentication model (see Related Documents below).
+
+## Related Documents
+
+- `bridgelet-product-audit/glossary/org-integration-api-key-model.md` — Companion document analyzing the API key authentication model in detail. This postmortem summarizes the documentation gap; the glossary document provides the full technical analysis.
+- `bridgelet-product-audit/postmortems/frd-and-technical-spec-overlap-unverified.md` — Another documentation consistency issue identified in the same audit.
+- `bridgelet-product-audit/postmortems/custodial-model-terminology-scope.md` — A cross-repo terminology gap that, like this issue, stems from documentation not keeping pace with implementation.
+- `bridgelet-product-audit/postmortems/claim-error-message-specificity-unverified.md` — A cross-repo consistency issue that, like this one, was identified but not fully resolved during the audit.


### PR DESCRIPTION
Closes #321
Closes #322
Closes #323
Closes #324

Adds 4 postmortem articles documenting FRD/technical-spec overlap, custodial model terminology scope, missing API key integration guide, and unverified claim error specificity.