### PR TITLE
docs: postmortems for fork URLs, stray file, PDF drift, lighthouse config

### DIFF
--- a/bridgelet-product-audit/postmortems/docs-pdf-mdx-drift-risk.md
+++ b/bridgelet-product-audit/postmortems/docs-pdf-mdx-drift-risk.md
@@ -1,0 +1,88 @@
+# Postmortem: PDF/MDX Drift Risk in `docs/`
+
+**Issue:** [#315](https://github.com/amberly-d/bridgelet/issues/315)
+**Severity:** Medium (documentation accuracy, especially security docs)
+**Status:** Open
+
+## Summary
+
+The `docs/` directory contains six PDF files. Three have corresponding `.mdx`
+sources; three exist only as PDFs. There is no automated step to regenerate the
+PDFs from their sources, so any drift between `.mdx` and `.pdf` is silent and
+undetectable in code review.
+
+## Evidence
+
+**Paired files (`.mdx` source + `.pdf` export):**
+
+| Source | PDF |
+|---|---|
+| `docs/architecture.mdx` | `docs/architecture.pdf` |
+| `docs/security-model.mdx` | `docs/security-model.pdf` |
+| `docs/integration-guide.mdx` | `docs/integration-guide.pdf` |
+
+**PDF-only files (no source):**
+
+| PDF | Has `.mdx`? |
+|---|---|
+| `docs/getting-started.pdf` | No |
+| `docs/mvp-specification.pdf` | No |
+| `docs/use-cases.pdf` | No |
+
+The root `package.json` has no `docs:pdf` script. No CI step was found that
+regenerates PDFs from `.mdx`. The existing runbook
+(`runbooks/rebuild-docs-pdf-from-mdx.md`) documents the manual procedure and
+notes that the toolchain is undocumented — the team must ask `git log` who last
+touched a PDF to figure out what produced it.
+
+## Why This Matters
+
+### Paired files — silent drift
+
+A contributor edits `security-model.mdx`, commits it, and opens a PR. The
+reviewer sees the markdown diff and approves. But `security-model.pdf` is never
+regenerated, so anyone who opens the PDF gets the **old** security guidance with
+no indicator it is stale. The security documentation specifically carries this
+risk — see
+[`glossary/docs-mdx-vs-pdf-pairs.md`](../glossary/docs-mdx-vs-pdf-pairs.md).
+
+- PDFs are binary blobs in git diffs — changes are invisible to reviewers.
+- PDFs are not greppable — terminology updates can miss them entirely.
+- Nothing fails when the two diverge.
+
+### PDF-only files — no source at all
+
+`getting-started.pdf`, `mvp-specification.pdf`, and `use-cases.pdf` have no
+editable source. Updating them requires reproducing the document from scratch in
+whatever tool originally created it, matching styling by eye. This is effectively
+a manual-only process with no audit trail.
+
+## Recommended Fix
+
+### For paired files (priority: high)
+
+1. **Add a CI step** that regenerates the PDFs from `.mdx` on every push to
+   `docs/**`, or at minimum validates that the checked-in PDF matches the source.
+2. **Alternatively, remove the PDFs** and serve the `.mdx` files through a docs
+   site (e.g. Docusaurus, Mintlify) where a single source of truth is always
+   current.
+3. Until automation is in place, **enforce in PR review** that any PR touching a
+   `.mdx` file also regenerates its paired PDF.
+
+### For PDF-only files (priority: medium)
+
+1. **Recover or recreate the source** — identify the original authoring tool,
+   extract or rewrite the content into `.mdx`, and add it to the repo.
+2. **Remove the orphan PDFs** once authoritative sources exist.
+3. If the content is genuinely archived (not meant to be maintained), move the
+   PDFs out of `docs/` into an `archive/` directory with a README explaining
+   their status.
+
+## Related Documents
+
+- [`glossary/docs-mdx-vs-pdf-pairs.md`](../glossary/docs-mdx-vs-pdf-pairs.md) —
+  canonical inventory of paired and orphan PDFs
+- [`runbooks/rebuild-docs-pdf-from-mdx.md`](../runbooks/rebuild-docs-pdf-from-mdx.md) —
+  the manual regeneration procedure
+- `docs/architecture.mdx`, `docs/security-model.mdx`, `docs/integration-guide.mdx` —
+  the three authoritative sources

--- a/bridgelet-product-audit/postmortems/lighthouserc-not-invoked.md
+++ b/bridgelet-product-audit/postmortems/lighthouserc-not-invoked.md
@@ -1,0 +1,119 @@
+# Postmortem: `lighthouserc.js` Exists But Is Not Invoked in Frontend CI
+
+**Issue:** [#316](https://github.com/amberly-d/bridgelet/issues/316)
+**Severity:** Medium (false confidence in quality gates)
+**Status:** Open
+
+## Summary
+
+A Lighthouse CI configuration exists at `frontend/lighthouserc.js` with
+performance, accessibility, and best-practices thresholds set to `error` level.
+However, the primary CI workflow (`frontend-ci.yml`) does not invoke Lighthouse.
+The config exists but is not wired into the merge gate that contributors
+actually rely on.
+
+## Evidence
+
+### The config — `frontend/lighthouserc.js`
+
+```js
+module.exports = {
+  ci: {
+    collect: {
+      startServerCommand: 'npm run start',
+      startServerReadyPattern: 'Ready',
+      url: [
+        'http://localhost:3000/',
+        'http://localhost:3000/send',
+        'http://localhost:3000/claim/abc123',
+      ],
+      numberOfRuns: 3,
+    },
+    assert: {
+      assertions: {
+        'categories:performance': ['error', { minScore: 0.85 }],
+        'categories:accessibility': ['error', { minScore: 0.95 }],
+        'categories:best-practices': ['error', { minScore: 0.90 }],
+        'categories:seo': ['off'],
+      },
+    },
+    upload: {
+      target: 'temporary-public-storage',
+    },
+  },
+};
+```
+
+Three thresholds are set to `error` — meaning they **should** block a merge
+when violated. Accessibility is held to the strictest bar (0.95).
+
+### The CI gap — `frontend-ci.yml`
+
+The frontend CI workflow runs:
+
+- `lint`
+- `type-check`
+- `test`
+- `build`
+
+It does **not** run `npm run lhci` or reference `lighthouserc.js` in any way.
+
+A separate `lighthouse-ci.yml` workflow exists (referenced in
+[`glossary/lighthouse-ci-config.md`](../glossary/lighthouse-ci-config.md)),
+but it is:
+
+- **Path-filtered** to `frontend/**`, `docs/**`, and its own workflow file — so
+  changes elsewhere skip it entirely.
+- **Dependent on `LHCI_GITHUB_APP_TOKEN`** from repository secrets, which is
+  typically unavailable to pull requests from forks.
+
+## Risk
+
+- **False confidence.** The thresholds read as enforced quality gates. A
+  contributor or reviewer might assume accessibility regressions will be caught.
+  They will not — unless the separate `lighthouse-ci.yml` happens to run and
+  has token access.
+- **Fork PRs escape entirely.** External contributors' PRs will never trigger
+  Lighthouse because they lack the app token. A significant accessibility
+  regression could merge without any Lighthouse signal.
+- **Config drift.** An unused config can drift from reality — the URLs it
+  audits (`/send`, `/claim/abc123`) may change without anyone noticing because
+  the gate is not actually enforced.
+
+## Recommended Fix
+
+### Option A — Add Lighthouse to `frontend-ci.yml` (preferred)
+
+Add a step after `build`:
+
+```yaml
+- name: Lighthouse CI
+  working-directory: frontend
+  run: npx lhci autorun
+  env:
+    LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+```
+
+If the token is unavailable for fork PRs, make the step non-blocking (`continue-on-error: true`)
+with a clear comment explaining why, so the gap is visible rather than implicit.
+
+### Option B — Remove the config
+
+If Lighthouse is not intended to be a merge gate, delete
+`frontend/lighthouserc.js` and remove the `@lhci/cli` dependency. A config that
+exists but is not enforced is worse than no config — it creates the illusion of
+a safety net.
+
+### Either way
+
+Update
+[`glossary/lighthouse-ci-config.md`](../glossary/lighthouse-ci-config.md) to
+reflect the actual state after the fix.
+
+## Related Documents
+
+- [`frontend/lighthouserc.js`](../../frontend/lighthouserc.js) — the unused config
+- [`glossary/lighthouse-ci-config.md`](../glossary/lighthouse-ci-config.md) —
+  glossary entry describing the Lighthouse setup
+- `frontend-ci.yml` — the CI workflow that should invoke (or explicitly skip)
+  Lighthouse

--- a/bridgelet-product-audit/postmortems/package-json-fork-urls.md
+++ b/bridgelet-product-audit/postmortems/package-json-fork-urls.md
@@ -1,0 +1,92 @@
+# Postmortem: Root `package.json` Points to Personal Fork
+
+**Issue:** [#313](https://github.com/amberly-d/bridgelet/issues/313)
+**Severity:** Low (cosmetic / registry metadata)
+**Status:** Open
+
+## Summary
+
+The root `package.json` contains `repository`, `bugs`, and `homepage` URLs that
+point to `https://github.com/okekefrancis112/bridgelet` — a personal fork —
+rather than the canonical `amberly-d/bridgelet` repository.
+
+## Evidence
+
+From `package.json` (lines 13–23):
+
+```json
+"repository": {
+  "type": "git",
+  "url": "git+https://github.com/okekefrancis112/bridgelet.git"
+},
+"bugs": {
+  "url": "https://github.com/okekefrancis112/bridgelet/issues"
+},
+"homepage": "https://github.com/okekefrancis112/bridgelet#readme"
+```
+
+All three metadata fields reference the same fork origin. No other `package.json`
+in the repo (e.g. `frontend/package.json`) was checked for the same issue, but
+the root file is the one exposed to npm tooling.
+
+## Impact
+
+### Direct npm command effects
+
+- **`npm home`** opens the fork's GitHub page, not the canonical repo.
+- **`npm repo`** opens the fork repository.
+- **`npm bugs`** opens the fork's issue tracker, where maintainers will not see
+  filed issues.
+
+### Registry metadata
+
+If this package were published to npm (even under a private registry), the
+registry listing would display the fork as the homepage, repository, and bug
+tracker. Anyone browsing the package page would be directed to the wrong place.
+
+### Scope
+
+Since this is the **root** `package.json`, every `npm` command invoked from the
+repo root inherits these incorrect URLs. This includes:
+
+- `npm install` (metadata in `node_modules/.package-lock.json`)
+- `npm info bridgelet` (registry lookups)
+- `npm repo bridgelet` (opening the repo from the CLI)
+
+This is not a runtime issue — no build or test breaks. But it means the public
+metadata surface of the package is misdirected, and any contributor who runs
+`npm repo` or `npm home` lands on the wrong fork.
+
+### How this likely happened
+
+The `package.json` was likely initialized or copied from `okekefrancis112`'s
+working fork and the URLs were never updated when the code moved to the
+canonical `amberly-d/bridgelet` repository. This is a common oversight in
+repos that originated as forks.
+
+## Recommended Fix
+
+Update the three URL fields in `package.json` to reference `amberly-d/bridgelet`:
+
+```json
+"repository": {
+  "type": "git",
+  "url": "git+https://github.com/amberly-d/bridgelet.git"
+},
+"bugs": {
+  "url": "https://github.com/amberly-d/bridgelet/issues"
+},
+"homepage": "https://github.com/amberly-d/bridgelet#readme"
+```
+
+Verification steps:
+
+1. Run `npm repo` from the root to confirm it opens the correct repository.
+2. Run `npm bugs` to confirm it opens the correct issue tracker.
+3. Grep all `package.json` files for `okekefrancis112` to ensure no other
+   copies carry the same fork URLs.
+
+## Related Documents
+
+- [`package.json`](../../package.json) — the file containing the fork URLs
+- [`glossary/governance-and-roadmap-cross-reference.md`](../glossary/governance-and-roadmap-cross-reference.md)

--- a/bridgelet-product-audit/postmortems/pr-body-md-stray-file.md
+++ b/bridgelet-product-audit/postmortems/pr-body-md-stray-file.md
@@ -1,0 +1,86 @@
+# Postmortem: Stray `pr_body.md` at Repository Root
+
+**Issue:** [#314](https://github.com/amberly-d/bridgelet/issues/314)
+**Severity:** Low (repo hygiene)
+**Status:** Open
+
+## Summary
+
+A file named `pr_body.md` exists at the repository root. It contains a
+PR description draft for the NFC feature (Closes #98), describing a Web NFC
+hook, send-flow integration, and evaluation document — work that was completed
+and merged under a separate PR.
+
+## Evidence
+
+The file is 15 lines long, lives at the repo root, and opens with:
+
+```markdown
+Closes #98
+
+### What does this PR do?
+This PR introduces an experimental feature using the Web NFC API to allow
+users to write a Bridgelet claim URL directly to a physical NFC tag.
+```
+
+It references specific source files (`frontend/hooks/use-nfc.ts`,
+`frontend/components/send-form/steps/confirm-step.tsx`,
+`docs/experiments/nfc-experiment.md`) and includes acceptance-criteria
+checkboxes. This is clearly a working draft for a PR body, not a maintained
+document.
+
+### What the file contains
+
+The full content describes:
+
+- **Web NFC Hook:** A `useNfc` React hook for writing URL records to NFC tags
+- **Send Flow Integration:** A "Write to NFC Tag" button in the confirm step
+- **NFC Evaluation Document:** An experiment writeup at `docs/experiments/nfc-experiment.md`
+- **Latent Type Fixes:** MSW module imports and Freighter API updates
+
+All acceptance criteria are checked off — this is post-merge debris.
+
+## Risk
+
+- **Scratch files accumulate.** If this file was not cleaned up after the PR
+  merged, other working notes may follow the same pattern — `.env.draft`,
+  `notes.md`, temporary screenshots, etc. Each one is a small hygiene failure
+  that compounds over time.
+- **No pre-commit or gitignore guard.** Its presence at root suggests no
+  `.gitignore` or pre-commit hook prevents temporary files from being committed.
+  There is no systematic defense against the next stray file.
+- **Confusion for new contributors.** A file named `pr_body.md` at root with
+  no explanation looks like either active work or forgotten debris. Either
+  reading wastes attention and creates ambiguity about what is authoritative.
+- **Closed issue reference.** `Closes #98` references a completed PR. The file
+  serves no ongoing purpose and the PR's own GitHub page is the canonical
+  record of what was merged.
+- **Search noise.** Anyone grepping the repo for NFC-related content will find
+  this stale draft alongside the actual implementation, potentially leading to
+  confusion about which description is current.
+
+## Recommended Fix
+
+1. **Delete `pr_body.md`.** The PR it describes is merged; the content lives in
+   the PR's own history on GitHub.
+2. **Add a `.gitignore` entry** (or enforce one) for common scratch patterns:
+   `pr_body.md`, `*.draft.md`, `.env.local`, etc.
+3. **Document the expectation** that working notes and draft PR descriptions
+   should not be committed to the repository — add a note to `CONTRIBUTING.md`
+   or the repo README.
+4. **Audit for other stray files.** Check for any other working drafts that may
+   have been committed by the same author or via the same workflow. Look for
+   patterns like `tmp_*`, `notes.md`, `TODO.md`, or screenshot files.
+
+## Why this pattern recurs
+
+PR description drafts are often written in a local file before being pasted into
+the GitHub PR form. If the contributor is working inside the repo directory, the
+draft file is right there — and `git add .` or a pre-commit workflow can easily
+sweep it up. The fix is both cultural (document the expectation) and mechanical
+(gitignore the patterns).
+
+## Related Documents
+
+- [`pr_body.md`](../../pr_body.md) — the stray file itself
+- [`glossary/governance-and-roadmap-cross-reference.md`](../glossary/governance-and-roadmap-cross-reference.md)


### PR DESCRIPTION
Closes #313
Closes #314
Closes #315
Closes #316

Adds 4 postmortem articles documenting package.json fork URLs, stray pr_body.md, docs PDF/MDX drift risk, and lighthouserc.js not invoked in CI.