### PR TITLE
docs: analytics runbook, mobile CI gap, test dir duplication, tsbuildinfo

### DIFF
--- a/bridgelet-product-audit/postmortems/mobile-app-zero-ci-coverage.md
+++ b/bridgelet-product-audit/postmortems/mobile-app-zero-ci-coverage.md
@@ -1,0 +1,93 @@
+# Postmortem: Mobile App Has Zero CI Coverage
+
+**Issue:** [#310](https://github.com/northersubair/bridgelet/issues/310)
+**Severity:** Medium
+**Status:** Open
+
+---
+
+## Summary
+
+The `mobile/` directory is a standalone Expo application with its own
+`package.json` and `package-lock.json`, yet it receives **no CI coverage**.
+Only `frontend/` is tested, linted, and type-checked in the existing GitHub
+Actions workflows.
+
+## What exists today
+
+The `.github/workflows/` directory contains two workflow files:
+
+| Workflow | What it covers | Scoped to |
+|---|---|---|
+| `frontend-ci.yml` | Lint, type-check, unit tests, build, Playwright e2e | `frontend/` via `working-directory` |
+| `lighthouse-ci.yml` | Lighthouse performance audit | `frontend/` |
+
+Neither workflow references `mobile/` in any way. There is no
+`mobile-ci.yml` or equivalent.
+
+## The gap
+
+`mobile/` is an independent Expo project. It has:
+
+```
+mobile/
+  package.json          # own scripts: lint, type-check, test
+  package-lock.json     # own dependency tree
+  ...                   # source files, config, etc.
+```
+
+This means:
+
+- **Lint regressions** in mobile TypeScript/TSX code merge uncaught.
+- **Type errors** ship to `main` without being flagged — mobile uses
+  `tsc --noEmit` (note: the script is named `type-check`, not `typecheck`).
+- **Unit test failures** in mobile tests are invisible to CI.
+- **Dependency vulnerabilities** specific to `mobile/package-lock.json` are not
+  scanned in any automated gate.
+
+## Risk assessment
+
+| Risk | Impact | Likelihood |
+|---|---|---|
+| Broken mobile build merges to `main` | Users on mobile get a broken release | Medium — no guard rails exist |
+| Type errors accumulate silently | Refactors become increasingly dangerous in `mobile/` | High — no type-check CI means drift compounds |
+| Lint rules diverge between `frontend/` and `mobile/` | Inconsistent code style across the two apps | High — each enforces its own ESLint config independently |
+| A PR touching both `mobile/` and `frontend/` passes CI only on the frontend side | Reviewers may assume full coverage based on green CI | High — the workflow names suggest broader coverage than they provide |
+
+## Contributing factors
+
+1. **Workflow scoping is invisible.** `frontend-ci.yml` has no path filter — it
+   runs on every push to `main` and every PR. A contributor unfamiliar with the
+   `working-directory: frontend` default might reasonably assume it covers the
+   whole repo.
+
+2. **No `build` script in mobile.** The Expo app uses `expo start` rather than
+   a discrete build step, so the pattern from `frontend-ci.yml` (which
+   unconditionally runs `npm run build`) cannot be copied verbatim.
+
+3. **Script name mismatch.** Mobile's type-check script is `type-check` (with a
+   hyphen), while `frontend-ci.yml` detects `"typecheck"` (no hyphen). Copying
+   the detection block without adjustment silently skips type-checking.
+
+## Recommendations
+
+1. **Create `.github/workflows/mobile-ci.yml`** scoped to `mobile/` via
+   `working-directory: mobile`. Mirror the structure of `frontend-ci.yml` but
+   adapt for mobile's actual scripts:
+   - `npm run lint`
+   - `npm run type-check` (note the hyphen)
+   - `npm run test`
+   - No build step unless a build equivalent is defined
+
+2. **Add path filters** so mobile CI only runs when `mobile/**` files change,
+   and frontend CI only runs when `frontend/**` files change. This makes the
+   coverage boundary explicit in the workflow itself.
+
+3. **Document the gap** in `CONTRIBUTING.md` or `TESTING.md` so contributors
+   know what CI does and does not cover.
+
+## Related Documents
+
+- [`onboard-mobile-app-to-ci.md`](../runbooks/onboard-mobile-app-to-ci.md) — runbook for implementing the fix
+- [`mobile-app-services-logger.md`](../glossary/mobile-app-services-logger.md) — context on mobile app internals
+- [`mobile-app-contract-awareness.md`](../integration-notes/mobile-app-contract-awareness.md) — mobile app's awareness of the contract layer

--- a/bridgelet-product-audit/postmortems/test-result-directory-duplication.md
+++ b/bridgelet-product-audit/postmortems/test-result-directory-duplication.md
@@ -1,0 +1,116 @@
+# Postmortem: `test-result` vs `test-results` Directory Duplication
+
+**Issue:** [#311](https://github.com/northersubair/bridgelet/issues/311)
+**Severity:** Low
+**Status:** Open
+
+---
+
+## Summary
+
+Two directories exist under `frontend/` whose names differ by a single trailing
+`s`:
+
+```
+frontend/test-result/     (singular)
+frontend/test-results/    (plural)
+```
+
+They contain entirely different kinds of content. The naming inversion — the
+singular name holds **source files**, the plural holds **generated output** — is
+a footgun that will cause confusion and potentially destructive cleanup.
+
+## What each directory contains
+
+### `frontend/test-result/` (singular)
+
+Contains **committed test source files** — Vitest specs that run in CI:
+
+```
+test-result/tests/app/claim-page-client.test.tsx
+test-result/tests/components/send-form/steps/confirm-step.test.tsx
+test-result/tests/components/send-form/steps/details-step.test.tsx
+test-result/tests/create-bridgelet-client.test.ts
+test-result/tests/lib/account-errors.test.ts
+test-result/tests/lib/bridgelet.test.ts
+```
+
+Despite the name suggesting output, this is **input**. These specs are picked up
+by `npm test` (`vitest run`) alongside the co-located `*.test.tsx` files
+elsewhere in `frontend/`.
+
+### `frontend/test-results/` (plural)
+
+Contains **Playwright run output** — generated artifacts, not sources:
+
+```
+test-results/.last-run.json
+test-results/send-flow-Send-flow-comple-73748-path-and-shows-a-claim-link-chromium/
+```
+
+`test-results/` is Playwright's default output directory name. The Playwright e2e
+tests and config were removed from this repo (commit `fbec7e4`, *"chore: remove
+playwright e2e tests and config"*), so this directory is a leftover artifact from
+a test run that predates that removal.
+
+The `.last-run.json` records:
+
+```json
+{
+  "status": "failed",
+  "failedTests": ["54450472bdffadeefdc0-5a0daee0bd3bb4baaa15"]
+}
+```
+
+A stale failure record for a spec that no longer exists in the repo.
+
+## Why this is dangerous
+
+| Scenario | What happens |
+|---|---|
+| "Cleaning up test output" by pattern-matching `test-result*` | Could delete **six live Vitest spec files** |
+| A script or CI step references `test-results/` expecting source tests | Gets Playwright artifacts instead — silent failure |
+| A developer `git rm`s `test-results/` thinking it is stale output | `.gitignore` already excludes it, but the confusion wastes time |
+| New contributor searches for tests by name | Finds Playwright output first, assumes tests are gone |
+
+The confusion runs in the **wrong direction**: the name that reads like output
+(`test-result`) is the one holding source you must not delete.
+
+## Contributing factors
+
+1. **Vitest chose a non-standard directory name.** The Vitest specs live in
+   `test-result/tests/` rather than the conventional `__tests__/` or
+   co-location next to source files. This makes them easy to overlook and hard
+   to distinguish from output at a glance.
+
+2. **Playwright was removed but its output directory was not cleaned up.** The
+   `test-results/` directory is gitignored but the directory itself persists on
+   disk, and the stale `.last-run.json` is a leftover from before commit
+   `fbec7e4`.
+
+3. **No documentation in the repo** explains which directory is which. The
+   glossary entry `test-result-directories.md` exists in the audit but is not
+   referenced from `README.md`, `TESTING.md`, or `CONTRIBUTING.md`.
+
+## Recommendations
+
+1. **Rename `frontend/test-result/`** to something unambiguous — e.g.
+   `frontend/tests/` or `frontend/__tests__/`. This eliminates the singular/plural
+   ambiguity and aligns with Vitest conventions.
+
+2. **Delete `frontend/test-results/` entirely.** It is gitignored, contains only
+   stale Playwright artifacts, and serves no purpose now that e2e tests have been
+   removed. If Playwright is re-added later, the default output directory will be
+   recreated automatically.
+
+3. **Update `TESTING.md`** to document where test files live and what the
+   directory structure looks like, so new contributors don't hit the same
+   confusion.
+
+4. **If the rename is done**, verify that `vitest.config.ts` or the `test`
+   script in `package.json` still resolves the correct path after the move.
+
+## Related Documents
+
+- [`test-result-directories.md`](../glossary/test-result-directories.md) — glossary entry documenting the two directories
+- [`docs-mdx-vs-pdf-pairs.md`](../glossary/docs-mdx-vs-pdf-pairs.md) — another example of similarly-named paired artifacts in this repo

--- a/bridgelet-product-audit/postmortems/tsbuildinfo-committed.md
+++ b/bridgelet-product-audit/postmortems/tsbuildinfo-committed.md
@@ -1,0 +1,94 @@
+# Postmortem: `tsconfig.tsbuildinfo` Is Committed to the Repository
+
+**Issue:** [#312](https://github.com/northersubair/bridgelet/issues/312)
+**Severity:** Low
+**Status:** Open
+
+---
+
+## Summary
+
+The file `frontend/tsconfig.tsbuildinfo` is tracked in git. This is a
+TypeScript incremental build cache file that should be in `.gitignore` — it is
+ephemeral, machine-specific, and provides no value in version control.
+
+## What `.tsbuildinfo` is
+
+When TypeScript's `tsc` is run with `--incremental` or `composite: true` in
+`tsconfig.json`, it produces a `.tsbuildinfo` file. This file stores:
+
+- A map of all source files and their output hash
+- Dependency relationships between compilation units
+- Checkpoint data allowing `tsc` to skip re-checking unchanged files
+
+On subsequent builds, `tsc` reads this file to determine what has changed and
+only re-checks the affected subset — a significant speedup for large projects.
+
+## Why it should not be committed
+
+| Problem | Explanation |
+|---|---|
+| **Goes stale immediately** | The file reflects the build state of whoever last ran `tsc`. On a different machine with different `node_modules`, it is meaningless. |
+| **Creates noisy diffs** | Every `tsc` run can update timestamps or hash values, producing diffs that add no semantic value. |
+| **Machine-specific content** | Paths and dependency hashes may differ across environments, causing unnecessary merge conflicts. |
+| **Rebuilt by CI anyway** | Any CI step running `tsc --noEmit` or `tsc --incremental` regenerates this file from scratch, so the committed version is never used. |
+| **Not the only cache file** | If `.tsbuildinfo` is committed, there is no reason not to commit `.turbo/`, `.next/cache/`, or any other build cache — the precedent is corrosive. |
+
+## Current state
+
+The file exists at:
+
+```
+frontend/tsconfig.tsbuildinfo
+```
+
+It is a single-line JSON blob containing an array of all TypeScript library and
+source file paths that `tsc` resolved during its last incremental build. The
+file is approximately 1 line (minified JSON), but represents hundreds of
+kilobytes of cache data.
+
+The repository's `.gitignore` does **not** include `*.tsbuildinfo` or
+`.tsbuildinfo`. The file was likely committed accidentally — a common occurrence
+when TypeScript incremental builds are enabled and the developer stages with
+`git add .`.
+
+## Practical impact
+
+- **Diff noise:** Any change to `tsconfig.json`, any new source file, or any
+  dependency update can cause the `.tsbuildinfo` contents to change, producing
+  commits that look significant in `git diff` but carry no intentional changes.
+- **Reviewer confusion:** A reviewer seeing a 100KB+ JSON blob in a PR may spend
+  time trying to understand it before realizing it is an auto-generated cache.
+- **False confidence:** A green CI that "passes the `.tsbuildinfo` check" means
+  nothing — the file is always regenerated.
+
+## Recommendations
+
+1. **Add to `.gitignore`:**
+
+   ```
+   *.tsbuildinfo
+   ```
+
+   This prevents future commits of the file.
+
+2. **Remove from tracking:**
+
+   ```bash
+   git rm --cached frontend/tsconfig.tsbuildinfo
+   ```
+
+   This stops git from tracking the file without deleting it from the working
+   directory.
+
+3. **Commit both changes together** — the `.gitignore` addition and the
+   `git rm --cached` — in a single commit. This makes the intent clear.
+
+4. **No functional change.** Removing the file from tracking has zero impact on
+   builds. `tsc` will regenerate it locally as needed, and CI runs `tsc --noEmit`
+   which does not use incremental cache anyway.
+
+## Related Documents
+
+- [`frontend/tsconfig.tsbuildinfo`](../../../frontend/tsconfig.tsbuildinfo) — the file in question
+- [`.gitignore`](../../../.gitignore) — needs the `*.tsbuildinfo` entry added

--- a/bridgelet-product-audit/runbooks/review-analytics-spec-before-new-event.md
+++ b/bridgelet-product-audit/runbooks/review-analytics-spec-before-new-event.md
@@ -1,0 +1,127 @@
+# Runbook: Review the Analytics Spec Before Adding a New Event
+
+**Issue:** [#290](https://github.com/northersubair/bridgelet/issues/290)
+**Purpose:** Pre-flight checklist for adding a new analytics event. Completing
+these steps before writing tracking code prevents naming drift, payload
+inconsistencies, and spec/code divergence.
+
+---
+
+## Step 1 — Search the spec for existing similar events
+
+Open [`docs/analytics-spec.md`](../../../docs/analytics-spec.md) and search for
+events in the same domain before inventing a new one.
+
+| What to search | Why |
+|---|---|
+| The noun you plan to use (e.g. `Payment`, `Claim`, `Wallet`) | An event may already exist for this object |
+| The verb you plan to use (e.g. `Created`, `Failed`) | Combining an existing noun with an existing verb may be redundant |
+| The journey section you expect the event to live in | Sender events are in §4, recipient events in §5, errors in §6 |
+
+If a semantically identical event already exists, **stop** — do not add a
+duplicate. If a close-but-not-identical event exists, note the distinction in
+your PR description so reviewers can evaluate whether one event should be reused
+or a new one is warranted.
+
+## Step 2 — Verify the naming follows `Noun Verb` Title Case
+
+The spec mandates a strict naming format (§2.1):
+
+```
+<Noun> <Past-Tense Verb>
+```
+
+Rules to check:
+
+- **Title Case** — `Claim Link Shared`, not `claim_link_shared` or
+  `claimLinkShared`
+- **Past tense verb only** — `Payment Created`, not `Create Payment` or
+  `Payment Create`
+- **No abbreviations** — `Wallet Address Entered`, not `Wallet Addr Entered`
+- **Error events prefix with `Error`** — `Error Displayed`, not `show_error`
+- **snake_case for payload keys** — `asset_type`, not `assetType`
+
+A quick test: does the event name read naturally as a sentence fragment?
+*"Payment Created"* works. *"Send Payment"* does not (that is imperative, not
+past tense).
+
+## Step 3 — Verify the payload matches the standard structure
+
+Every event must include the **base payload** defined in §3.1 of the spec:
+
+```jsonc
+{
+  "anonymous_id": "string",
+  "session_id": "string",
+  "journey": "sender | recipient | shared",
+  "timestamp": "ISO 8601 string",
+  "platform": "web",
+  "network": "testnet | mainnet",
+  "user_agent": "string",
+  "device_type": "mobile | tablet | desktop",
+  "referrer": "string | null",
+  "app_version": "string"
+}
+```
+
+Then check whether your event needs any **conditional properties** from §3.2:
+
+- `claim_id` — if the event relates to a specific claim
+- `asset_type` — if the event involves a particular asset
+- `amount_usd_equiv` — if the event involves a monetary amount
+- `expiry_days` — if the event involves link expiry
+- `error_code` / `error_type` — if the event reports an error
+
+Do not add custom properties without first checking whether an existing
+conditional property already covers the data you need. The spec is the single
+source of truth for payload shape.
+
+## Step 4 — Update the spec before implementing code
+
+The spec is defined as a **design document, not an after-the-fact record** (§1
+states: *"This document defines what to track and how to structure it. It does
+not implement any tracking code."*).
+
+Update `docs/analytics-spec.md` with your new event **before** writing the
+tracking implementation. Specifically:
+
+1. Add the event name and description to the appropriate journey section
+   (§4 Sender, §5 Recipient, or §6 Error & Edge Cases).
+2. Include a row in the journey's event table with the event name, trigger
+   condition, and any event-specific properties.
+3. If the event introduces a new conditional property, add it to the §3.2 table.
+
+This ordering ensures the spec remains the authoritative reference. A PR that
+ships tracking code without a spec update will be flagged in review.
+
+## Step 5 — Confirm the event appears in the correct journey section
+
+After updating the spec, verify placement:
+
+- **Sender journey (§4):** Events triggered by Alice's actions — creating a
+  payment, copying a link, connecting a wallet.
+- **Recipient journey (§5):** Events triggered by Bob's actions — opening a
+  claim link, submitting a claim, connecting a wallet.
+- **Error & Edge Cases (§6):** Events that fire on failures or exceptional
+  conditions — network errors, validation failures, timeouts.
+
+If the event can occur in **either** journey, use `journey: "shared"` in the
+payload and place it in whichever section is most natural. Note the cross-
+applicability in the event description.
+
+---
+
+## Checklist summary
+
+- [ ] Searched `docs/analytics-spec.md` for duplicates or near-matches
+- [ ] Name follows `Noun Verb` Title Case, past tense
+- [ ] Payload includes all base fields (§3.1) plus relevant conditional fields
+- [ ] Spec updated with the new event before code implementation
+- [ ] Event placed in the correct journey section
+
+## Related Documents
+
+- [`docs/analytics-spec.md`](../../../docs/analytics-spec.md) — the canonical event spec
+- [`analytics-spec-overview.md`](../glossary/analytics-spec-overview.md) — glossary entry summarizing the spec structure
+- [`analytics-events-vs-onchain-outcomes.md`](../integration-notes/analytics-events-vs-onchain-outcomes.md) — which events are confirmed on-chain vs optimistic
+- [`investigate-analytics-event-gap.md`](investigate-analytics-event-gaps.md) — runbook for when an expected event is missing from dashboards


### PR DESCRIPTION
Closes #290
Closes #310
Closes #311
Closes #312

Adds 1 runbook for analytics spec pre-flight review and 3 postmortems documenting mobile CI coverage gap, test-result directory duplication, and committed tsbuildinfo artifact.