### PR TITLE
fix: workflow CI bug (submitted state) + product audit FAQ docs

### DIFF
--- a/bridgelet-product-audit/faq/how-do-i-know-my-claim-link-is-safe.md
+++ b/bridgelet-product-audit/faq/how-do-i-know-my-claim-link-is-safe.md
@@ -1,0 +1,109 @@
+# FAQ: How do I know a claim link someone sent me is legitimate?
+
+**Short answer:** A genuine Bridgelet claim link is a signed, single-use JWT
+embedded in the URL path. Knowing what makes a link trustworthy — and what it
+cannot protect against — helps you decide whether to act on one.
+
+---
+
+## What a claim URL actually is
+
+A claim URL looks like:
+
+```
+https://app.bridgelet.org/claim/<token>
+```
+
+The `<token>` segment is a **JWT signed by the Bridgelet backend** using a
+secret the frontend never sees. Per `docs/security-model.mdx`:
+
+- **Integrity-protected** — the JWT signature guarantees the token was issued
+  by the backend and has not been tampered with.
+- **Single-use** — the token is consumed on redemption and cannot be replayed.
+- **High-entropy** — derived from a UUID v4 `accountId` (122 bits); brute-force
+  enumeration is not feasible, and verify calls are rate-limited.
+- **Path segment, not query string** — deliberately, to avoid leaking the token
+  in `Referer` headers.
+
+Full technical detail is in
+[`integration-notes/claim-url-security-properties.md`](../integration-notes/claim-url-security-properties.md).
+
+---
+
+## The bearer problem: the link is the credential
+
+This is the most important thing to understand:
+
+> **Whoever holds the link can attempt the claim.** There is no identity check
+> binding the token to an intended recipient.
+
+The token is a *bearer credential* — like cash in an envelope, not an addressed
+letter. If someone else obtains the link before you act on it, they can claim
+the funds first. The security model logs this as **threat T-01 (claim token
+theft)** and rates it mitigated — but the mitigation is *single-use*, not
+*identity-bound*. First valid redemption wins.
+
+### What this means in practice
+
+| Scenario | Outcome |
+|----------|---------|
+| You receive the link and claim it | ✅ Funds are swept to your wallet |
+| A thief intercepts the link and claims it first | ❌ You find a spent token; the real sender must contact support |
+| Someone tries the same link again after you claimed | ❌ Already-swept guard rejects it on-chain |
+
+The best protection is how the link is delivered. The security model's
+recommendation: **share via end-to-end encrypted channels** (Signal, WhatsApp,
+etc.), not unencrypted email, shared tickets, or chat channels where link
+previews may fire.
+
+---
+
+## What "safe" actually means here
+
+When assessing a claim link sent to you, consider:
+
+1. **Is the domain correct?** The URL should resolve to the legitimate Bridgelet
+   frontend (e.g., `app.bridgelet.org`). A phishing site can copy the UI but
+   cannot forge a valid signed JWT for a real backend account.
+
+2. **Did the link come from the expected sender?** The claim-link delivery
+   channel is outside Bridgelet's control. If someone you don't recognise sends
+   you a claim link, verify with the sender out-of-band before connecting your
+   wallet.
+
+3. **Is the link still valid?** Ephemeral accounts expire. If you see an
+   "expired" or "already claimed" error, the funds are either reclaimed by the
+   sender (expiry) or already swept (claimed by someone).
+
+---
+
+## An open question about sender communication
+
+There is a known open item: whether the `/send` flow adequately communicates
+to senders that the claim URL is a bearer token that should be treated as
+sensitive. If senders don't understand this, they may share links in unsafe
+channels. This is tracked in the audit knowledge base.
+
+---
+
+## Security disclosure
+
+If you discover a vulnerability in how claim links are generated, validated,
+or delivered, follow the responsible disclosure process in
+[`SECURITY.md`](../../SECURITY.md).
+
+---
+
+## Related documents
+
+- [`integration-notes/claim-url-security-properties.md`](../integration-notes/claim-url-security-properties.md)
+  — full technical analysis of claim URL security properties
+- [`glossary/claim-token-and-claim-url.md`](../glossary/claim-token-and-claim-url.md)
+  — definitions and properties
+- [`docs/security-model.mdx`](../../docs/security-model.mdx) — broader security
+  posture, threat model, and T-01/T-13 threat entries
+- [`SECURITY.md`](../../SECURITY.md) — responsible disclosure process
+
+---
+
+*Part of the bridgelet-product-audit/ knowledge-base initiative.*

--- a/bridgelet-product-audit/faq/how-does-bridgelet-relate-to-bridgelet-sdk-and-core.md
+++ b/bridgelet-product-audit/faq/how-does-bridgelet-relate-to-bridgelet-sdk-and-core.md
@@ -1,0 +1,97 @@
+# FAQ: How does this repo relate to bridgelet-sdk and bridgelet-core?
+
+**Short answer:** Bridgelet is a three-layer system across three repositories.
+This repo (bridgelet) contains the client apps. It calls `bridgelet-sdk` (the
+backend API), which in turn calls `bridgelet-core` (the Soroban smart
+contracts on Stellar).
+
+---
+
+## The three-layer architecture
+
+```
+bridgelet (this repo)
+  └─ frontend/   — Next.js web reference UI
+  └─ mobile/     — Expo React Native app
+       │
+       │  HTTP calls to bridgelet-sdk API
+       ▼
+bridgelet-sdk
+  └─ NestJS backend API
+  └─ Orchestrates account creation, claim validation, sweep execution
+       │
+       │  Soroban RPC calls to bridgelet-core
+       ▼
+bridgelet-core
+  └─ Soroban smart contracts (Rust)
+  └─ On-chain enforcement of account restrictions and single-use sweep rules
+```
+
+| Layer | Repo | Technology | Responsibility |
+|-------|------|------------|----------------|
+| 1. Client apps | **bridgelet** (this repo) | Next.js + Expo (TypeScript) | UI, wallet connection, API calls |
+| 2. Backend API | **bridgelet-sdk** | NestJS (TypeScript) | Business logic, account lifecycle, SDK consumers integrate here |
+| 3. Smart contracts | **bridgelet-core** | Soroban (Rust) | On-chain restrictions, single-use enforcement, sweep authorisation |
+
+---
+
+## Why three separate repositories?
+
+Each layer has a distinct deployment model and consumer:
+
+- **bridgelet-core** is deployed to the Stellar blockchain. Organizations that
+  want on-chain guarantees interact with it directly via Soroban RPC.
+- **bridgelet-sdk** is a backend service. Organizations integrate it into their
+  payment infrastructure (e.g. alongside the Stellar Disbursement Platform).
+  It abstracts the contract complexity behind a REST API.
+- **bridgelet** (this repo) is a reference UI. It demonstrates how a frontend
+  or mobile app should call the SDK. Organizations can fork it or build their
+  own UI against the same SDK endpoints.
+
+---
+
+## Practical implication: a bug could originate in any layer
+
+When tracing a failure — say, a claim link that resolves as "already swept"
+when it shouldn't — the error may live at any of the three layers:
+
+| Stage | What could go wrong |
+|-------|---------------------|
+| bridgelet-core | Contract state machine has an unexpected transition |
+| bridgelet-sdk | Error string matching fails to map the contract error to a structured code |
+| bridgelet (this repo) | API error is not propagated to a user-visible message; fallback fires |
+
+The general tracing approach for following an error across all three layers is
+documented in
+[`integration-notes/three-repo-error-surface-consistency.md`](../integration-notes/three-repo-error-surface-consistency.md).
+That document walks through a concrete example (`AlreadySwept`) end-to-end and
+identifies where identity can be lost.
+
+---
+
+## Where the knowledge bases cross-reference each other
+
+Each repository has its own audit knowledge-base folder using the same
+conventions (`postmortems/`, `runbooks/`, `glossary/`, etc.). Where an issue
+spans multiple layers, the relevant document in each repo links to its
+counterpart in the others. For instance:
+
+- This repo's `integration-notes/three-repo-error-surface-consistency.md`
+  references `bridgelet-sdk-audit/error-mapping-completeness-checklist.md`.
+- `bridgelet-core`'s audit documents are referenced from
+  `integration-notes/mobile-app-contract-awareness.md`.
+
+---
+
+## Related documents
+
+- [`integration-notes/three-repo-error-surface-consistency.md`](../integration-notes/three-repo-error-surface-consistency.md)
+  — tracing an error from contract through SDK to frontend UI
+- [`README.md`](../../README.md) — top-level overview of all three repositories
+  with links to their GitHub locations
+- [`docs/architecture.mdx`](../../docs/architecture.mdx) — system design and
+  component interaction diagrams
+
+---
+
+*Part of the bridgelet-product-audit/ knowledge-base initiative.*

--- a/bridgelet-product-audit/faq/is-there-a-login-session.md
+++ b/bridgelet-product-audit/faq/is-there-a-login-session.md
@@ -1,0 +1,78 @@
+# FAQ: Is there a login session or account system for senders?
+
+**Short answer:** No. Bridgelet deliberately has no session tokens, cookies, or
+server-side accounts. Wallet ownership is proved at transaction-signing time —
+the signature is the credential.
+
+---
+
+## Why there is no session
+
+`docs/sender-auth-model.md` evaluates three options and selects **Option B:
+no session token, proof at signing time**:
+
+> No session token or JWT is created. Wallet ownership is proven at
+> transaction-signing time. The public key identifies the sender; the
+> transaction signature is the implicit proof of auth.
+
+The alternatives were rejected explicitly:
+
+| Option | Rejected because |
+|--------|-----------------|
+| A — Static `X-API-Key` | Key would leak in the JS bundle shipped to the browser. |
+| C — No auth (open send) | Unmitigated spam/abuse risk. |
+
+This design maps naturally to Stellar's mental model: you own a key, you prove
+ownership by signing. There is no separate auth step because signing *is* the
+auth step.
+
+For the full design rationale, see
+[`postmortems/sender-auth-relies-on-transaction-signing-not-session.md`](../postmortems/sender-auth-relies-on-transaction-signing-not-session.md).
+
+---
+
+## What wallet connection persistence actually is
+
+When you connect Freighter in the `/send` flow, the frontend writes your public
+key and wallet type to `localStorage` under the key `bridgelet_wallet`. This is
+a **UI convenience** — it lets the form pre-populate on reload so you don't have
+to reconnect every time.
+
+It is **not** an authenticated session:
+
+- No token is issued to the server.
+- No server-side record is created.
+- Clearing `localStorage` (or clicking "Disconnect") removes only the
+  auto-reconnect shortcut — it does not "log you out" of anything.
+
+See [`glossary/connected-wallet-persistence.md`](../glossary/connected-wallet-persistence.md)
+for the exact storage key, shape, and what is (and is not) stored.
+
+---
+
+## Practical takeaway
+
+> Proof of wallet ownership happens at **transaction-signing time, every time.**
+
+Each time you create a payment, Freighter prompts you to sign the transaction
+XDR. That signature is the server's proof that you control the funding wallet.
+There is nothing to "stay logged in to" and nothing to "log out of" between
+payment creations.
+
+---
+
+## Related documents
+
+- [`docs/sender-auth-model.md`](../../docs/sender-auth-model.md) — decision
+  record for Option B
+- [`postmortems/sender-auth-relies-on-transaction-signing-not-session.md`](../postmortems/sender-auth-relies-on-transaction-signing-not-session.md)
+  — full design analysis, tradeoffs, and implications
+- [`glossary/sender-vs-recipient-auth-models.md`](../glossary/sender-vs-recipient-auth-models.md)
+  — how sender auth (wallet-based) differs from recipient auth (claim-token
+  bearer model)
+- [`glossary/connected-wallet-persistence.md`](../glossary/connected-wallet-persistence.md)
+  — what is actually stored in `localStorage`
+
+---
+
+*Part of the bridgelet-product-audit/ knowledge-base initiative.*

--- a/bridgelet-product-audit/faq/why-is-mobile-behind-the-web-app.md
+++ b/bridgelet-product-audit/faq/why-is-mobile-behind-the-web-app.md
@@ -1,0 +1,79 @@
+# FAQ: Why does the mobile app seem less complete than the web frontend?
+
+**Short answer:** The mobile app (`mobile/`) is at an earlier stage of
+development than the web frontend (`frontend/`). Two concrete, observable
+signals confirm this as a factual current-state observation.
+
+---
+
+## Signal 1: The mobile app has zero CI coverage
+
+The `.github/workflows/` directory contains two workflow files:
+
+| Workflow | What it covers | Scoped to |
+|---|---|---|
+| `frontend-ci.yml` | Lint, type-check, unit tests, build, Playwright e2e | `frontend/` |
+| `lighthouse-ci.yml` | Lighthouse performance audit | `frontend/` |
+
+Neither workflow references `mobile/` in any way. This means lint regressions,
+type errors, and unit test failures in the mobile codebase merge uncaught —
+there is no automated gate.
+
+This is documented in full in
+[`postmortems/mobile-app-zero-ci-coverage.md`](../postmortems/mobile-app-zero-ci-coverage.md),
+including the risk assessment and a recommended fix (creating
+`.github/workflows/mobile-ci.yml`).
+
+---
+
+## Signal 2: Only one `services/` subdirectory is populated
+
+The `mobile/services/` directory — the layer that would connect the mobile UI
+to the Bridgelet backend SDK — contains only a `logger/` subdirectory. The
+services needed to create accounts, validate claim tokens, or execute sweeps
+are not yet implemented there.
+
+This is documented in
+[`glossary/mobile-app-services-logger.md`](../glossary/mobile-app-services-logger.md).
+
+---
+
+## This is a factual observation, not a judgment
+
+The gap between the two clients reflects development priorities, not a
+permanent architectural decision. The web frontend was built first as the
+reference implementation demonstrating SDK integration. The mobile app is
+scaffolded and in progress.
+
+**For future plans**, refer to [`ROADMAP.md`](../../ROADMAP.md), which tracks
+what is planned across both clients.
+
+---
+
+## Specific gaps between mobile and web
+
+A tracked list of concrete feature and infrastructure gaps is maintained in the
+audit knowledge base. The key categories are:
+
+- No CI pipeline for mobile (lint, type-check, unit tests)
+- Service layer not yet wired to bridgelet-sdk
+- Wallet connection flow (Freighter, LOBSTR, generated) parity with web
+- No Playwright or equivalent E2E tests for mobile flows
+
+---
+
+## Related documents
+
+- [`postmortems/mobile-app-zero-ci-coverage.md`](../postmortems/mobile-app-zero-ci-coverage.md)
+  — full analysis of the missing CI coverage and recommendations
+- [`glossary/mobile-app-services-logger.md`](../glossary/mobile-app-services-logger.md)
+  — what exists today in `mobile/services/`
+- [`integration-notes/mobile-app-contract-awareness.md`](../integration-notes/mobile-app-contract-awareness.md)
+  — how the mobile app relates to the Soroban contract layer
+- [`runbooks/onboard-mobile-app-to-ci.md`](../runbooks/onboard-mobile-app-to-ci.md)
+  — step-by-step runbook for adding mobile CI
+- [`ROADMAP.md`](../../ROADMAP.md) — planned work across both clients
+
+---
+
+*Part of the bridgelet-product-audit/ knowledge-base initiative.*

--- a/frontend/components/send-form/steps/confirm-step.tsx
+++ b/frontend/components/send-form/steps/confirm-step.tsx
@@ -60,6 +60,7 @@ type SubmitPhase = 'idle' | 'preparing' | 'awaiting-freighter' | 'submitting';
 
 export function ConfirmStep({ state, onBack }: ConfirmStepProps) {
   const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
   const [submitPhase, setSubmitPhase] = useState<SubmitPhase>('idle');
   const [signingModeUsed, setSigningModeUsed] = useState<'freighter-client' | 'backend' | null>(
     null,


### PR DESCRIPTION
## Summary

This PR fixes a workflow-blocking CI bug in the send form and adds four FAQ documents to the `bridgelet-product-audit/` knowledge base.

---

## Bug fix: `ReferenceError: submitted is not defined`

**File:** `frontend/components/send-form/steps/confirm-step.tsx`

The `ConfirmStep` component called `setSubmitted(true)` and guarded the success view with `if (submitted)`, but the `submitted` state variable was never declared. This caused a `ReferenceError` in all 9 confirm-step tests, blocking the Frontend CI workflow.

**Fix:** Added the missing state declaration:
```ts
const [submitted, setSubmitted] = useState(false);
```

All 141 unit tests now pass.

---

## FAQ documentation

Closes #335 — `bridgelet-product-audit/faq/is-there-a-login-session.md`
Closes #336 — `bridgelet-product-audit/faq/how-do-i-know-my-claim-link-is-safe.md`
Closes #337 — `bridgelet-product-audit/faq/why-is-mobile-behind-the-web-app.md`
Closes #340 — `bridgelet-product-audit/faq/how-does-bridgelet-relate-to-bridgelet-sdk-and-core.md`

Each FAQ is documentation-only, scoped to the new `bridgelet-product-audit/faq/` folder. No changes to `frontend/` or `mobile/` source code were needed for the FAQ items.

---

## Checklist

- [x] Bug fix: `submitted` state variable declared
- [x] All 141 unit tests pass (`vitest run` — 22 test files)
- [x] FAQ #335: login session / no-session auth model
- [x] FAQ #336: claim link safety / bearer-token nature
- [x] FAQ #337: mobile vs web maturity gap
- [x] FAQ #340: three-repo architecture relationship
- [x] No `frontend/` or `mobile/` source changes for FAQ items