### PR TITLE
fix(security): add Referrer-Policy: no-referrer to /claim/:token route

### DIFF
--- a/docs/security-model.mdx
+++ b/docs/security-model.mdx
@@ -101,6 +101,31 @@ Recipients are unauthenticated. The claim token embedded in the URL is the sole 
 
 ## Claim Token Security
 
+### Claim Token Placement — Path vs Fragment
+
+The claim credential is embedded in the URL **path segment** (`/claim/<token>`) rather than a URL fragment (`/claim#token=<token>`) or a query parameter (`/claim?token=<token>`). This placement was an explicit design choice with the following rationale and mitigations:
+
+**Why path segment, not fragment:**
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Path segment — `/claim/<token>` (current) | Fully server-routable; SSR can validate/serve the correct page without JS; works reliably across all browsers, link-unfurlers, and QR codes | Token appears in `Referer` header sent to sub-resource origins; appears in server access logs; stored in browser history |
+| URL fragment — `/claim#token=<token>` | Never sent to the server or in `Referer` by spec; not stored in standard server logs | Requires client-side JS to extract before any API call; degrades badly without JS; many QR-code and messaging clients strip or mangle fragments; link previews break |
+| Query string — `/claim?token=<token>` | Fully server-routable | Same `Referer` exposure as path; additionally logged by many WAF/CDN products that strip fragments but preserve query strings |
+
+The **URL fragment approach offers stronger passive-leak protection** (the token is never transmitted to the server or in `Referer`) but has unacceptable reliability tradeoffs for a financial product: fragment stripping is common in SMS apps, email clients, and QR code readers — exactly the channels Bridgelet recipients use. A broken claim link for a non-technical user is a worse outcome than a mitigated-but-present referrer-leak risk.
+
+**Mitigations applied for the path-segment placement:**
+
+1. **`Referrer-Policy: no-referrer`** — Set via `next.config.js` `headers()` on the `/claim/:token` route. This instructs the browser not to send a `Referer` header for any navigation away from or sub-resource loaded on the claim page. This is the primary mitigation.
+2. **No third-party scripts or CDNs on the claim page** — The claim page must not load Google Fonts, analytics beacons, or any cross-origin sub-resource that would receive a `Referer`. Any future addition of such resources requires explicit security review.
+3. **Server-side access log redaction** — Production deployments of `bridgelet-sdk` and any proxy/CDN layer (e.g., CloudFront, Nginx, Vercel) must redact or exclude request path values that match `/claim/<token>` patterns from stored logs.
+4. **Short-lived tokens** — Default token expiry is 30 days. Reducing this window for high-value claims limits the exposure period if a token does leak.
+
+**Decision:** Keep path-segment placement with mitigations (1)–(4) above. Revisit fragment placement only if a reliable fragment-preservation guarantee can be provided end-to-end for the supported share channels.
+
+---
+
 Claim tokens are **JWTs signed by the backend** using a secret the frontend never sees.
 
 **Token lifecycle:**
@@ -186,6 +211,7 @@ The table below covers threats identified in the original security model PDF, up
 | T-13 | **Sweep execution without authorization** — backend sweeps funds to wrong address or without valid claim | Backend logic error / compromised process | Sweep requires: (a) valid unexpired claim token, (b) server-side signature with ephemeral private key. No client-supplied authorization credential. | ⚠️ **MVP STUB — see §8** |
 | T-14 | **Stellar network outage** — funds locked in ephemeral account during network disruption | External (Stellar) | Graceful error UI with retry. Ephemeral account persists until claimed or expired; funds are recoverable once network resumes. | ✅ Mitigated (degraded mode) |
 | T-15 | **Private key leak from generated wallet** — `generateNewWallet()` exposes a raw secret key in-browser | Frontend code path | `generateNewWallet()` in `lib/wallet.ts` returns the secret key directly to the caller. This flow is not presented in the UI by default. | ⚠️ Partial — secret handling requires audit |
+| T-16 | **Claim token leaks via `Referer` header** — claim token in URL path forwarded to third-party sub-resources or CDN logs | `Referer` header on `/claim/<token>` page; browser history; server access logs | `Referrer-Policy: no-referrer` set in `next.config.js` for `/claim/:token`. No third-party scripts permitted on claim page. Log redaction required in production deployments. Token placement rationale documented in §Claim Token Security. | ✅ Mitigated (header set; see §Claim Token Security for full mitigation list) |
 
 ---
 

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -4,6 +4,46 @@ const nextConfig = {
   turbopack: {
     root: __dirname,
   },
+
+  /**
+   * HTTP response headers applied per-route.
+   *
+   * /claim/[token] places the claim credential in the URL path, which means
+   * it would be forwarded in the `Referer` request header to every
+   * sub-resource loaded on that page (fonts, analytics beacons, images).
+   * Because this token authorises a fund sweep, leaking it to a third-party
+   * CDN or analytics endpoint before the recipient claims is a genuine
+   * funds-security risk (see issue #392 and docs/security-model.mdx §Claim
+   * Token Security).
+   *
+   * `Referrer-Policy: no-referrer` ensures the browser sends no `Referer`
+   * header at all for any navigation *away from* or sub-resource *loaded on*
+   * the claim page.  This is the most conservative choice and is appropriate
+   * here because:
+   *   1. The claim page has no SEO value that depends on referrer analytics.
+   *   2. No third-party widgets on this page need the origin URL to function.
+   *   3. The alternative — `strict-origin-when-cross-origin` — would still
+   *      send the full path (including the token) to same-origin sub-resources,
+   *      which is unnecessarily broad.
+   *
+   * Note: the path segment decision (vs. URL fragment `#token=...`) is
+   * documented in docs/security-model.mdx under "Claim Token Placement".
+   */
+  async headers() {
+    return [
+      {
+        // Matches /claim/<any-token> — Next.js header source patterns use
+        // :param notation, not the [param] file-system convention.
+        source: '/claim/:token',
+        headers: [
+          {
+            key: 'Referrer-Policy',
+            value: 'no-referrer',
+          },
+        ],
+      },
+    ];
+  },
 };
 
 module.exports = nextConfig;

--- a/frontend/tests/next-config-headers.test.ts
+++ b/frontend/tests/next-config-headers.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Tests that next.config.js declares the `Referrer-Policy: no-referrer` header
+ * for the `/claim/:token` route.
+ *
+ * We test the config module directly rather than spinning up a Next.js server
+ * so these can run fast inside the existing Vitest suite (no network / process
+ * overhead).  The important behaviour we are asserting is that the header
+ * declaration is present and correctly formed — a misconfigured export would
+ * be caught here before it ever reaches CI or a browser.
+ */
+
+import { describe, it, expect } from 'vitest';
+import path from 'path';
+
+// next.config.js lives one directory above this test file (frontend/).
+// __dirname here is frontend/tests/, so we go up one level.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const nextConfig = require(path.resolve(__dirname, '../next.config.js')) as {
+  headers?: () => Promise<
+    Array<{
+      source: string;
+      headers: Array<{ key: string; value: string }>;
+    }>
+  >;
+};
+
+describe('next.config.js — security headers', () => {
+  it('exports a headers() function', () => {
+    expect(typeof nextConfig.headers).toBe('function');
+  });
+
+  it('declares Referrer-Policy: no-referrer for /claim/:token', async () => {
+    const headerRules = await nextConfig.headers!();
+
+    const claimRule = headerRules.find((rule) => rule.source === '/claim/:token');
+    expect(claimRule, 'Expected a header rule for /claim/:token').toBeDefined();
+
+    const referrerHeader = claimRule!.headers.find(
+      (h) => h.key.toLowerCase() === 'referrer-policy',
+    );
+    expect(referrerHeader, 'Expected a Referrer-Policy header entry').toBeDefined();
+    expect(referrerHeader!.value).toBe('no-referrer');
+  });
+
+  it('does not emit the Referrer-Policy header for other routes', async () => {
+    const headerRules = await nextConfig.headers!();
+
+    // Routes such as /, /send, /roadmap must not carry the claim-page header —
+    // applying it broadly would suppress analytics referrer data site-wide.
+    const nonClaimRoutes = headerRules.filter((rule) => rule.source !== '/claim/:token');
+    for (const rule of nonClaimRoutes) {
+      const has = rule.headers.some((h) => h.key.toLowerCase() === 'referrer-policy');
+      expect(has, `Unexpected Referrer-Policy on route ${rule.source}`).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #392

The claim credential lives in the URL path (). Without a  header, any sub-resource loaded on the claim page (fonts, analytics, images) would receive the full URL—including the token—in the browser's `Referer` request header. Because this token authorises a fund sweep, leaking it to a third-party CDN or analytics endpoint before redemption is a genuine funds-security risk.

## Changes

### `frontend/next.config.js`
- Added `headers()` export setting `Referrer-Policy: no-referrer` for the `/claim/:token` source pattern.
- Scoped strictly to that route so no other pages are affected.
- Inline comment explains the security rationale and why `no-referrer` was chosen over `strict-origin-when-cross-origin`.

### `frontend/tests/next-config-headers.test.ts` (new)
Three Vitest unit tests:
1. `headers()` function is exported.
2. `Referrer-Policy: no-referrer` is present for `/claim/:token`.
3. No other route inadvertently carries the header.

### `docs/security-model.mdx`
- New **§Claim Token Placement — Path vs Fragment** sub-section under §Claim Token Security documenting the path/fragment/query comparison, the decision to keep path-segment placement, and the four mitigations applied.
- Added **T-16** to the threat model table: *Claim token leaks via Referer header* → ✅ Mitigated.

## Testing

```bash
cd frontend
npm test          # 37 tests pass (3 new)
npm run typecheck # no errors
npm run build     # clean
```

## Acceptance criteria

- [x] `/claim/[token]` sends `Referrer-Policy: no-referrer` — confirmed in `next.config.js` headers export and unit-tested.
- [x] Decision on path-vs-fragment token placement is documented with rationale in `docs/security-model.mdx`.
- [x] No third-party network requests on the claim page (no analytics beacons, no external font CDNs in the current codebase — documented as a restriction).
- [x] Logging audit note added to the security model (production deployments must redact claim paths from access logs — documented in the mitigation list).