### PR TITLE
feat: cross-repo compatibility matrix + CI check (#395)

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -1,0 +1,280 @@
+name: Cross-Repo Compatibility
+
+# Verifies that the bridgelet-sdk commit pinned in compatibility.json still
+# works with this frontend, per the process documented in
+# docs/compatibility.md. This is deliberately a *separate* workflow from
+# e2e.yml: e2e.yml exercises the frontend against MSW mocks (fast, no
+# external dependency) on every relevant PR, while this workflow exercises
+# it against a real bridgelet-sdk checkout, which is slower and depends on
+# secrets that aren't available to fork PRs.
+#
+# See docs/compatibility.md#required-ci-secrets for what BRIDGELET_SDK_*
+# unlocks and what still gets checked without it.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'compatibility.json'
+      - 'docs/compatibility.md'
+      - 'e2e/**'
+      - 'frontend/app/**'
+      - 'frontend/components/**'
+      - 'frontend/lib/**'
+
+  schedule:
+    # Daily, offset from e2e.yml's 06:00 run so the two don't contend for
+    # runners.
+    - cron: '0 7 * * *'
+
+  workflow_dispatch: {}
+
+jobs:
+  compatibility:
+    name: Verify pinned bridgelet-sdk combination
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: bridgelet_user
+          POSTGRES_PASSWORD: bridgelet_pass
+          POSTGRES_DB: bridgelet
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U bridgelet_user -d bridgelet"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - name: Checkout bridgelet (frontend)
+        uses: actions/checkout@v4
+        with:
+          path: bridgelet
+
+      # ── Resolve the pinned bridgelet-sdk commit ──────────────────────────────
+
+      - name: Read pinned bridgelet-sdk ref from compatibility.json
+        id: pin
+        working-directory: bridgelet
+        run: |
+          node -e '
+            const c = require("./compatibility.json");
+            const sdk = c.verified && c.verified.bridgeletSdk;
+            if (!sdk || !sdk.commit || !sdk.repo) {
+              console.error("compatibility.json is missing verified.bridgeletSdk.{repo,commit}");
+              process.exit(1);
+            }
+            console.log(`repo=${sdk.repo}`);
+            console.log(`commit=${sdk.commit}`);
+            console.log(`version=${sdk.version}`);
+          ' >> "$GITHUB_OUTPUT"
+
+      - name: Checkout pinned bridgelet-sdk commit
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ steps.pin.outputs.repo }}
+          ref: ${{ steps.pin.outputs.commit }}
+          path: bridgelet-sdk
+
+      # ── Node setup ──────────────────────────────────────────────────────────
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: |
+            bridgelet/frontend/package-lock.json
+            bridgelet/e2e/package-lock.json
+            bridgelet-sdk/package-lock.json
+
+      # ── Install ────────────────────────────────────────────────────────────
+
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: bridgelet/frontend
+
+      - name: Install e2e dependencies
+        run: npm ci
+        working-directory: bridgelet/e2e
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+        working-directory: bridgelet/e2e
+
+      - name: Install bridgelet-sdk dependencies
+        run: npm ci
+        working-directory: bridgelet-sdk
+
+      # ── Determine how much of the job we can actually run ────────────────────
+      #
+      # BRIDGELET_SDK_* secrets carry a funded Stellar testnet keypair and
+      # live bridgelet-core contract IDs. They aren't available on fork PRs
+      # and must be provisioned by a maintainer (docs/compatibility.md#required-ci-secrets).
+      # Without them we still verify install/build/migrate/boot below —
+      # we just can't assert on the funded send -> claim -> sweep flow.
+
+      - name: Check whether live-testnet secrets are configured
+        id: secrets
+        env:
+          HAS_FUNDING_SECRET: ${{ secrets.BRIDGELET_SDK_FUNDING_ACCOUNT_SECRET != '' }}
+        run: echo "configured=${HAS_FUNDING_SECRET}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate a throwaway keypair for the boot-only smoke path
+        if: steps.secrets.outputs.configured != 'true'
+        id: throwaway
+        working-directory: bridgelet-sdk
+        run: |
+          node -e '
+            const { Keypair } = require("@stellar/stellar-sdk");
+            const kp = Keypair.random();
+            console.log(`secret=${kp.secret()}`);
+            console.log(`public=${kp.publicKey()}`);
+          ' >> "$GITHUB_OUTPUT"
+
+      # ── Configure and boot bridgelet-sdk ─────────────────────────────────────
+
+      - name: Run database migrations
+        working-directory: bridgelet-sdk
+        env:
+          DATABASE_HOST: localhost
+          DATABASE_PORT: '5432'
+          DATABASE_NAME: bridgelet
+          DATABASE_USER: bridgelet_user
+          DATABASE_PASSWORD: bridgelet_pass
+        run: npm run migration:run
+
+      - name: Build bridgelet-sdk
+        working-directory: bridgelet-sdk
+        run: npm run build
+
+      - name: Start bridgelet-sdk
+        working-directory: bridgelet-sdk
+        env:
+          NODE_ENV: test
+          PORT: '4000'
+          OTEL_ENABLED: 'false'
+          CORS_ORIGINS: http://localhost:3000
+          DATABASE_HOST: localhost
+          DATABASE_PORT: '5432'
+          DATABASE_NAME: bridgelet
+          DATABASE_USER: bridgelet_user
+          DATABASE_PASSWORD: bridgelet_pass
+          DATABASE_SYNC: 'false'
+          STELLAR_NETWORK: testnet
+          STELLAR_HORIZON_URL: https://horizon-testnet.stellar.org
+          STELLAR_SOROBAN_RPC_URL: https://soroban-testnet.stellar.org
+          # Funded testnet keypair when available; otherwise a freshly
+          # generated (unfunded) keypair so the process still boots — see
+          # the "live-testnet secrets" step above.
+          FUNDING_ACCOUNT_SECRET: ${{ secrets.BRIDGELET_SDK_FUNDING_ACCOUNT_SECRET || steps.throwaway.outputs.secret }}
+          RECOVERY_ACCOUNT_PUBLIC: ${{ secrets.BRIDGELET_SDK_RECOVERY_ACCOUNT_PUBLIC || steps.throwaway.outputs.public }}
+          EPHEMERAL_ACCOUNT_CONTRACT_ID: ${{ secrets.BRIDGELET_SDK_EPHEMERAL_ACCOUNT_CONTRACT_ID || 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4' }}
+          STELLAR_SWEEP_CONTROLLER_CONTRACT_ID: ${{ secrets.BRIDGELET_SDK_SWEEP_CONTROLLER_CONTRACT_ID || 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4' }}
+          SWEEP_SIGNING_KEY_SEED: f76f684a3a8b64f32a7dc7eba0b0a5040ba66b5ea67dad348c3b69b79db3339c
+          JWT_SECRET: ci-compatibility-job-not-a-real-secret
+          # 64 hex chars (32 bytes) — CI-only value, not a real secret.
+          ENCRYPTION_KEY: '9ef61d8fe679ea10433353f5488a91eabbaf831d9f8e422ba8f89636778683ed'
+          CLAIM_TOKEN_EXPIRY: '2592000'
+        run: |
+          nohup npm run start > ../bridgelet-sdk.log 2>&1 &
+          echo $! > ../bridgelet-sdk.pid
+
+      - name: Wait for bridgelet-sdk to become healthy
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:4000/health > health.json; then
+              echo "bridgelet-sdk is up:"
+              cat health.json
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::bridgelet-sdk did not become healthy within 60s"
+          cat bridgelet-sdk.log || true
+          exit 1
+
+      # ── Primary gate: does the frontend's hand-written API client still
+      #    match what this bridgelet-sdk commit actually serves? ───────────────
+      #
+      # frontend/lib/bridgelet.ts / frontend/lib/create-bridgelet-client.ts
+      # assume specific bridgelet-sdk endpoints and field names. This fetches
+      # the pinned SDK's live OpenAPI spec (GET /api/docs-json) and asserts
+      # those endpoints/fields still exist — catching exactly the "frontend
+      # assumes a response shape/endpoint a different SDK version doesn't
+      # provide" failure mode this issue is about, without needing a funded
+      # testnet account, so it runs on every PR and scheduled run regardless
+      # of secrets. See scripts/check-sdk-contract.mjs for exactly what's
+      # checked (and its known limits — it's field-presence, not full type
+      # equivalence).
+
+      - name: Check frontend/bridgelet-sdk API contract
+        working-directory: bridgelet
+        env:
+          BRIDGELET_API_URL: http://localhost:4000
+        run: node scripts/check-sdk-contract.mjs
+
+      # ── Secondary, best-effort: exercise the flows that are actually wired
+      #    through to the real SDK in the browser e2e suite ────────────────────
+      #
+      # frontend/components/mock-provider.tsx currently auto-enables MSW
+      # whenever NODE_ENV=development regardless of E2E_USE_MOCKS, and at
+      # least one flow (claim-flow.tsx's redeem handler) has a hardcoded
+      # dev-mode stub — so this step does not yet exercise every route
+      # against bridgelet-sdk end-to-end. It's kept because it still catches
+      # regressions in what *is* wired, and to give the "SDK integration"
+      # mode documented in e2e/README.md a real CI run. The OpenAPI check
+      # above is the authoritative pass/fail signal for this job.
+
+      - name: Run e2e suite in SDK-integration mode (best-effort — see comment above)
+        if: steps.secrets.outputs.configured == 'true'
+        continue-on-error: true
+        id: e2e
+        run: npx playwright test --reporter=github
+        working-directory: bridgelet/e2e
+        env:
+          CI: true
+          E2E_USE_MOCKS: 'false'
+          E2E_BASE_URL: http://localhost:3000
+          E2E_API_BASE_URL: http://localhost:4000
+
+      - name: Job summary
+        if: always()
+        run: |
+          echo "### Compatibility check — bridgelet-sdk @ \`${{ steps.pin.outputs.commit }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- OpenAPI type contract: authoritative pass/fail signal for this job (see step above)." >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ steps.secrets.outputs.configured }}" = "true" ]; then
+            echo "- Browser e2e suite (SDK-integration mode): ran, best-effort, outcome '${{ steps.e2e.outcome }}' — does not fail the job; see e2e/README.md and this workflow's comments for known coverage gaps." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "- Browser e2e suite (SDK-integration mode): skipped — \`BRIDGELET_SDK_FUNDING_ACCOUNT_SECRET\` and related secrets are not configured (see docs/compatibility.md#required-ci-secrets)." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      # ── Artifacts ────────────────────────────────────────────────────────────
+
+      - name: Upload Playwright report
+        if: always() && steps.secrets.outputs.configured == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: compatibility-playwright-report-${{ github.run_id }}
+          path: |
+            bridgelet/frontend/test-results/
+            bridgelet/e2e/playwright-report/
+          retention-days: 14
+
+      - name: Upload bridgelet-sdk log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: compatibility-sdk-log-${{ github.run_id }}
+          path: bridgelet-sdk.log
+          retention-days: 7
+
+      - name: Stop bridgelet-sdk
+        if: always()
+        run: kill "$(cat bridgelet-sdk.pid)" 2>/dev/null || true

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -182,7 +182,21 @@ jobs:
           ENCRYPTION_KEY: '9ef61d8fe679ea10433353f5488a91eabbaf831d9f8e422ba8f89636778683ed'
           CLAIM_TOKEN_EXPIRY: '2592000'
         run: |
-          nohup npm run start > ../bridgelet-sdk.log 2>&1 &
+          # Don't assume `npm run start` (node dist/main.js) is correct:
+          # bridgelet-sdk's tsconfig.build.json doesn't exclude the
+          # top-level scripts/ directory, so tsc's inferred rootDir is the
+          # project root rather than src/, and `nest build` actually emits
+          # dist/src/main.js, not dist/main.js. Their own CI never runs the
+          # built output (only `npm run build`), so this drifted unnoticed.
+          # Locate the real entry point instead of hardcoding the path.
+          ENTRY=$(find dist -name main.js -not -path '*/node_modules/*' | head -1)
+          if [ -z "$ENTRY" ]; then
+            echo "::error::Could not find a built main.js under dist/ after 'npm run build'."
+            find dist -maxdepth 3 || true
+            exit 1
+          fi
+          echo "Starting bridgelet-sdk via: node $ENTRY"
+          nohup node "$ENTRY" > ../bridgelet-sdk.log 2>&1 &
           echo $! > ../bridgelet-sdk.pid
 
       - name: Wait for bridgelet-sdk to become healthy

--- a/.release-it.json
+++ b/.release-it.json
@@ -7,6 +7,9 @@
     "release": true,
     "releaseName": "v${version}"
   },
+  "hooks": {
+    "before:git:release": "node scripts/check-compatibility-doc.mjs"
+  },
   "plugins": {
     "@release-it/conventional-changelog": {
       "preset": "conventionalcommits",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Cross-repo compatibility matrix (`docs/compatibility.md`, `compatibility.json`) documenting which frontend releases are verified against which `bridgelet-sdk` / `bridgelet-core` versions, a `compatibility.yml` CI job that checks out the pinned `bridgelet-sdk` commit and fails the build if its live OpenAPI spec no longer has an endpoint or field the frontend's API client depends on (`scripts/check-sdk-contract.mjs`), and a `release-it` `before:git:release` hook (`scripts/check-compatibility-doc.mjs`) that blocks tagging a release until the matrix has been updated
 - Playwright E2E suite for the reference UI (`frontend/playwright.config.ts`, `frontend/e2e/`) targeting `localhost:3000`, with `test:e2e` / `test:e2e:ui` scripts and Frontend CI running E2E against the built Next.js app
 - Initial MVP implementation of Bridgelet for ephemeral Stellar accounts
 - **bridgelet-core**: Soroban smart contracts for on-chain account restrictions, sweep logic, and event emission ([bridgelet-core](https://github.com/bridgelet-org/bridgelet-core))

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Comprehensive documentation is available in the [`/docs`](./docs) directory:
 | [💡 Use Cases & Examples](https://github.com/bridgelet-org/bridgelet/raw/main/docs/use-cases.pdf)      | Real-world use cases and examples                |
 | [📋 MVP Specification](https://github.com/bridgelet-org/bridgelet/raw/main/docs/mvp-specification.pdf) | Minimum viable product requirements              |
 | [🧪 Testing Guide](./TESTING.md)                                                                       | Testing strategy, Lighthouse CI, and guidelines  |
+| [🔗 Compatibility Matrix](./docs/compatibility.md)                                                     | Which frontend releases are verified against which bridgelet-sdk / bridgelet-core versions |
 | [🔐 Freighter Sender Signing Experiment](./docs/experiments/freighter-sender-signing.md)               | Client-side Freighter signing for account creation |
 
 > **📌 Note:** If PDFs don't render in your browser, click the links above to download them directly, or see the [docs directory](./docs) for more information.
@@ -110,6 +111,12 @@ For backend or smart contract development, please refer to the specific reposito
 - **[bridgelet-sdk](https://github.com/bridgelet-org/bridgelet-sdk)** - Backend SDK (NestJS + TypeScript)
 - **[bridgelet-core](https://github.com/bridgelet-org/bridgelet-core)** - Smart contracts (Soroban + Rust)
 - **bridgelet** - Reference UI implementation and documentation (This repository)
+
+Each repo is versioned and released independently — see the
+[Compatibility Matrix](./docs/compatibility.md) for which combinations of
+frontend / `bridgelet-sdk` / `bridgelet-core` versions are known to work
+together, and [`.github/workflows/compatibility.yml`](./.github/workflows/compatibility.yml)
+for the CI job that verifies it.
 
 ## MVP Scope (v0.1)
 

--- a/compatibility.json
+++ b/compatibility.json
@@ -1,0 +1,24 @@
+{
+  "$comment": "Machine-readable source of truth for cross-repo version compatibility. Read by .github/workflows/compatibility.yml (to pin the bridgelet-sdk checkout) and by scripts/check-compatibility-doc.mjs (to gate `release-it` on docs/compatibility.md being up to date). See docs/compatibility.md for the human-readable matrix and update process.",
+  "frontend": {
+    "repo": "bridgelet-org/bridgelet",
+    "version": "1.0.0"
+  },
+  "verified": {
+    "bridgeletSdk": {
+      "repo": "bridgelet-org/bridgelet-sdk",
+      "version": "0.0.1",
+      "ref": "main",
+      "commit": "42e3cdef4b2edca4134e4a7f9f977749c53a54db"
+    },
+    "bridgeletCore": {
+      "repo": "bridgelet-org/bridgelet-core",
+      "version": "unreleased",
+      "ref": "main",
+      "commit": "47bb6751b0e989bbcdf3cb6efda92679b7b6d983"
+    }
+  },
+  "status": "pinned",
+  "pinnedOn": "2026-08-22",
+  "statusNote": "'pinned' means this is the combination CI is configured to check, not yet a passing result. Flip to 'verified' (and add the run URL to docs/compatibility.md's matrix row) once .github/workflows/compatibility.yml's contract-check job has passed against this exact commit pair — that check does not require BRIDGELET_SDK_* secrets; those only unlock the workflow's secondary, best-effort browser e2e run."
+}

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,118 @@
+# Cross-Repo Compatibility Matrix
+
+Bridgelet is split across three independently versioned and independently
+released repositories:
+
+| Repo | Role |
+|---|---|
+| [`bridgelet-core`](https://github.com/bridgelet-org/bridgelet-core) | Soroban smart contracts (on-chain account restrictions) |
+| [`bridgelet-sdk`](https://github.com/bridgelet-org/bridgelet-sdk) | Backend API (NestJS) that the frontend talks to and that calls `bridgelet-core` |
+| `bridgelet` (this repo) | Reference Next.js frontend + docs |
+
+Because each repo ships on its own cadence, a given frontend release only
+behaves correctly against specific `bridgelet-sdk` (and, transitively,
+`bridgelet-core`) versions — a newer or older SDK can rename a response
+field, change an endpoint, or expect a contract ID the frontend doesn't
+know about. This table is the record of which combinations have actually
+been exercised together, so nobody has to guess or find out in production.
+
+## Matrix
+
+| `bridgelet` (this repo) | `bridgelet-sdk` | `bridgelet-core` | Status | Verified |
+|---|---|---|---|---|
+| `main` (unreleased, root `package.json` `1.0.0`) | `main` @ [`42e3cde`](https://github.com/bridgelet-org/bridgelet-sdk/commit/42e3cdef4b2edca4134e4a7f9f977749c53a54db) (`0.0.1`) | `main` @ [`47bb675`](https://github.com/bridgelet-org/bridgelet-core/commit/47bb6751b0e989bbcdf3cb6efda92679b7b6d983) | 🟡 Pinned, not yet CI-verified | — |
+
+**Status legend**
+
+| Status | Meaning |
+|---|---|
+| 🟢 Verified | The pinned combination has a passing run of `.github/workflows/compatibility.yml` — see the linked run in the *Verified* column. |
+| 🟡 Pinned | The combination is what CI is configured to check next, but no run has passed yet. |
+| 🔴 Broken | A CI run against this pin failed. Do not deploy this frontend version against this SDK version. |
+
+Neither `bridgelet-sdk` nor `bridgelet-core` has cut a tagged release yet,
+so the current row pins to a commit SHA on `main` rather than a semver
+tag. Once either repo starts tagging releases, new rows should pin to
+tags (e.g. `v0.2.0`) instead of raw commits.
+
+## Machine-readable source of truth
+
+The row above is generated from [`compatibility.json`](../compatibility.json)
+at the repo root, which is what both CI and the release process actually
+read:
+
+- [`.github/workflows/compatibility.yml`](../.github/workflows/compatibility.yml)
+  checks out `bridgelet-sdk` at `verified.bridgeletSdk.commit`, boots it, and
+  runs [`scripts/check-sdk-contract.mjs`](../scripts/check-sdk-contract.mjs)
+  against its live OpenAPI spec (`GET /api/docs-json`) — the job fails if an
+  endpoint or field that
+  [`frontend/lib/create-bridgelet-client.ts`](../frontend/lib/create-bridgelet-client.ts)
+  depends on is missing, which is exactly the "frontend assumes a response
+  shape/endpoint a different SDK version doesn't provide" failure mode this
+  doc exists to catch. (It checks field-name presence, not full type or enum
+  equivalence — see the script's header comment for what it does and does
+  not catch.) When `BRIDGELET_SDK_*` secrets are configured (see below) the
+  job additionally runs the frontend's e2e suite (`e2e/`) in "SDK
+  integration" mode (see
+  [`e2e/README.md`](../e2e/README.md#running-against-a-real-bridgelet-sdk-instance))
+  as a best-effort secondary check — the workflow's own comments note which
+  flows that suite doesn't yet exercise end-to-end.
+- [`scripts/check-compatibility-doc.mjs`](../scripts/check-compatibility-doc.mjs)
+  is run by `release-it` (via `.release-it.json`'s `before:git:release`
+  hook) and blocks tagging a new release until this file and
+  `compatibility.json` have been updated to match the version being
+  released.
+
+## Updating the matrix
+
+Do this whenever `bridgelet-sdk` or `bridgelet-core` cuts a release you
+want the frontend verified against, and always as part of cutting a new
+`bridgelet` release:
+
+1. Update `compatibility.json`:
+   - Bump `frontend.version` to the version about to be released (must
+     match the root [`package.json`](../package.json) `version`).
+   - Update `verified.bridgeletSdk` / `verified.bridgeletCore` to the
+     `ref`/`commit`/`version` you want CI to check.
+   - Set `status` back to `"pinned"` and update `pinnedOn` — CI flips it
+     to `verified` conceptually once the workflow run below is green (add
+     the run URL to this file's matrix row manually).
+2. Push the change (or open the PR containing it) — `.github/workflows/compatibility.yml`
+   runs on PRs that touch `compatibility.json` and on its daily schedule.
+3. Once the workflow passes, add a row to the **Matrix** table above with
+   the verified versions, the ✅ status, and a link to the passing run.
+4. `npm run release` (or however `release-it` is invoked) will refuse to
+   tag if step 1 wasn't done for the version being released — see
+   [`scripts/check-compatibility-doc.mjs`](../scripts/check-compatibility-doc.mjs).
+
+## Required CI secrets
+
+The live-network portion of `.github/workflows/compatibility.yml` starts a
+real `bridgelet-sdk` instance against Stellar **testnet**, which needs a
+funded testnet account and deployed `bridgelet-core` contract IDs. These
+are organization secrets, not something a contributor's PR can supply:
+
+| Secret | Used for |
+|---|---|
+| `BRIDGELET_SDK_FUNDING_ACCOUNT_SECRET` | `bridgelet-sdk`'s `FUNDING_ACCOUNT_SECRET` — the testnet keypair that funds ephemeral accounts |
+| `BRIDGELET_SDK_RECOVERY_ACCOUNT_PUBLIC` | `bridgelet-sdk`'s `RECOVERY_ACCOUNT_PUBLIC` |
+| `BRIDGELET_SDK_EPHEMERAL_ACCOUNT_CONTRACT_ID` | Deployed `bridgelet-core` `EphemeralAccount` contract ID on testnet |
+| `BRIDGELET_SDK_SWEEP_CONTROLLER_CONTRACT_ID` | Deployed `bridgelet-core` `SweepController` contract ID on testnet |
+
+If these secrets aren't set (e.g. in a fork), the job's pass/fail result is
+unaffected: the OpenAPI contract check above installs, builds, migrates,
+and boots the pinned `bridgelet-sdk` using an unfunded, freshly generated
+throwaway keypair, then checks its live spec — none of that requires real
+funds. Only the secondary, best-effort browser e2e run is skipped, and the
+job summary says so explicitly rather than reporting a false pass. See the
+workflow file for exactly which steps are gated.
+
+## Known gap this check does not close
+
+While building this check we found that `frontend`'s `AccountStatus` type
+(`pending | claimed | expired`) does not match `bridgelet-sdk`'s actual
+`AccountStatus` enum (`pending_payment | pending_claim | claimed | expired
+| failed`). `scripts/check-sdk-contract.mjs` deliberately checks field
+*names*, not enum values, so it does not fail on this — seeded here as a
+known, pre-existing drift for whoever picks it up next, not something
+introduced or fixed by this change.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   },
   "scripts": {
     "build": "npm --prefix frontend run build",
-    "test": "echo \"Run npm test inside frontend/ for app tests\" && exit 0"
+    "test": "echo \"Run npm test inside frontend/ for app tests\" && exit 0",
+    "check:compatibility": "node scripts/check-compatibility-doc.mjs",
+    "check:sdk-contract": "node scripts/check-sdk-contract.mjs"
   },
   "repository": {
     "type": "git",
@@ -16,12 +18,17 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC", 
+  "license": "ISC",
   "bugs": {
     "url": "https://github.com/okekefrancis112/bridgelet/issues"
   },
   "homepage": "https://github.com/okekefrancis112/bridgelet#readme",
   "dependencies": {
     "puppeteer": "^24.36.0"
+  },
+  "bridgeletCompatibility": {
+    "description": "Pinned bridgelet-sdk/bridgelet-core versions this repo is verified against. See compatibility.json (source of truth) and docs/compatibility.md (matrix + process).",
+    "manifest": "compatibility.json",
+    "docs": "docs/compatibility.md"
   }
 }

--- a/scripts/check-compatibility-doc.mjs
+++ b/scripts/check-compatibility-doc.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * Blocks `release-it` from tagging a release until docs/compatibility.md
+ * and compatibility.json have been updated for the version being released.
+ *
+ * Wired up as release-it's `hooks.before:git:release` in .release-it.json.
+ * See docs/compatibility.md#updating-the-matrix for the process this
+ * enforces.
+ *
+ * Checks:
+ *   1. compatibility.json's `frontend.version` matches the version about
+ *      to be tagged (release-it bumps package.json before this hook runs).
+ *   2. docs/compatibility.md's matrix table has a row for that version.
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+
+function fail(message) {
+  console.error(`\n✖ ${message}\n`);
+  console.error('See docs/compatibility.md#updating-the-matrix — update compatibility.json');
+  console.error('and add a matrix row in docs/compatibility.md before tagging this release.\n');
+  process.exit(1);
+}
+
+const pkg = JSON.parse(readFileSync(resolve(repoRoot, 'package.json'), 'utf8'));
+const releaseVersion = pkg.version;
+
+if (!releaseVersion) {
+  fail('package.json has no "version" field — cannot check compatibility docs against it.');
+}
+
+const compat = JSON.parse(readFileSync(resolve(repoRoot, 'compatibility.json'), 'utf8'));
+
+if (compat.frontend?.version !== releaseVersion) {
+  fail(
+    `compatibility.json's frontend.version ("${compat.frontend?.version}") does not match ` +
+      `the version being released ("${releaseVersion}").`,
+  );
+}
+
+if (compat.status !== 'verified') {
+  fail(
+    `compatibility.json's status is "${compat.status}", not "verified". ` +
+      `.github/workflows/compatibility.yml must have a passing run against the pinned ` +
+      `bridgelet-sdk/bridgelet-core commits before this version can be tagged.`,
+  );
+}
+
+const doc = readFileSync(resolve(repoRoot, 'docs/compatibility.md'), 'utf8');
+
+if (!doc.includes(releaseVersion)) {
+  fail(
+    `docs/compatibility.md does not mention version "${releaseVersion}" — add a matrix row ` +
+      `for this release before tagging.`,
+  );
+}
+
+console.log(`✓ docs/compatibility.md and compatibility.json are up to date for v${releaseVersion}.`);

--- a/scripts/check-sdk-contract.mjs
+++ b/scripts/check-sdk-contract.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * Cross-repo compatibility check: verifies that a running bridgelet-sdk
+ * instance still exposes the endpoints, request fields, and response
+ * fields that this frontend's hand-written API client depends on
+ * (frontend/lib/create-bridgelet-client.ts, frontend/lib/bridgelet.ts).
+ *
+ * This intentionally does NOT diff frontend/lib/bridgelet.ts against
+ * generated output — that file predates/diverged from
+ * frontend/scripts/generate-types.mjs's openapi-typescript output shape,
+ * so a full-file diff would always show a rewrite regardless of real
+ * compatibility. Field-name presence in the live OpenAPI spec is the
+ * signal that actually catches "frontend assumes a response shape or
+ * endpoint a different SDK version doesn't provide" (the failure mode
+ * from bridgelet issue #395) without false positives.
+ *
+ * Scope: endpoint existence + top-level request/response field-name
+ * presence. It does NOT check field types or enum values — e.g. it would
+ * not catch the SDK's AccountStatus enum (pending_payment/pending_claim/
+ * claimed/expired/failed) differing from the frontend's AccountStatus
+ * type (pending/claimed/expired). That's a real, pre-existing drift this
+ * script does not cover; see docs/compatibility.md.
+ *
+ * Usage:
+ *   BRIDGELET_API_URL=http://localhost:4000 node scripts/check-sdk-contract.mjs
+ */
+
+const apiUrl = process.env.BRIDGELET_API_URL ?? 'http://localhost:4000';
+const specUrl = `${apiUrl}/api/docs-json`;
+
+/** @type {{method: string, path: string, requestFields?: string[], responseStatus: string, responseFields?: string[]}[]} */
+const CONTRACT = [
+  {
+    method: 'post',
+    path: '/accounts',
+    requestFields: ['fundingSource', 'recovery_address', 'amount', 'expiresIn'],
+    responseStatus: '201',
+    responseFields: [
+      'accountId',
+      'publicKey',
+      'claimUrl',
+      'amount',
+      'asset',
+      'status',
+      'expiresAt',
+      'createdAt',
+    ],
+  },
+  {
+    method: 'get',
+    path: '/accounts/{id}',
+    responseStatus: '200',
+    responseFields: ['accountId', 'publicKey', 'claimUrl', 'amount', 'asset', 'status', 'expiresAt'],
+  },
+  {
+    method: 'post',
+    path: '/claims/verify',
+    requestFields: ['claimToken'],
+    responseStatus: '200',
+  },
+  {
+    method: 'post',
+    path: '/claims/redeem',
+    requestFields: ['claimToken', 'destinationAddress'],
+    responseStatus: '200',
+    responseFields: ['success', 'amountSwept', 'asset', 'destination'],
+  },
+];
+
+function resolveSchema(spec, schema) {
+  if (!schema) return undefined;
+  if (schema.$ref) {
+    const name = schema.$ref.replace('#/components/schemas/', '');
+    return resolveSchema(spec, spec.components?.schemas?.[name]);
+  }
+  if (Array.isArray(schema.allOf)) {
+    const properties = {};
+    for (const part of schema.allOf) {
+      Object.assign(properties, resolveSchema(spec, part)?.properties ?? {});
+    }
+    return { ...schema, properties };
+  }
+  return schema;
+}
+
+function fieldNames(spec, schema) {
+  return Object.keys(resolveSchema(spec, schema)?.properties ?? {});
+}
+
+async function main() {
+  console.log(`Fetching OpenAPI spec from: ${specUrl}`);
+  const res = await fetch(specUrl);
+  if (!res.ok) {
+    console.error(`::error::Could not fetch OpenAPI spec: HTTP ${res.status}`);
+    process.exit(1);
+  }
+  const spec = await res.json();
+
+  const errors = [];
+
+  for (const check of CONTRACT) {
+    const label = `${check.method.toUpperCase()} ${check.path}`;
+    const operation = spec.paths?.[check.path]?.[check.method];
+
+    if (!operation) {
+      errors.push(`${label}: endpoint not found in the SDK's OpenAPI spec.`);
+      continue;
+    }
+
+    if (check.requestFields) {
+      const bodySchema = operation.requestBody?.content?.['application/json']?.schema;
+      const actual = fieldNames(spec, bodySchema);
+      const missing = check.requestFields.filter((f) => !actual.includes(f));
+      if (missing.length > 0) {
+        errors.push(
+          `${label}: request body is missing field(s) the frontend sends: ${missing.join(', ')} ` +
+            `(spec has: ${actual.join(', ') || '(none)'}).`,
+        );
+      }
+    }
+
+    if (check.responseFields) {
+      const responseSchema =
+        operation.responses?.[check.responseStatus]?.content?.['application/json']?.schema;
+      const actual = fieldNames(spec, responseSchema);
+      const missing = check.responseFields.filter((f) => !actual.includes(f));
+      if (missing.length > 0) {
+        errors.push(
+          `${label} -> ${check.responseStatus}: response is missing field(s) the frontend reads: ` +
+            `${missing.join(', ')} (spec has: ${actual.join(', ') || '(none)'}).`,
+        );
+      }
+    }
+
+    console.log(`  ✓ ${label}`);
+  }
+
+  if (errors.length > 0) {
+    console.error('\nCross-repo contract check failed:\n');
+    for (const err of errors) console.error(`::error::${err}`);
+    console.error(
+      '\nThis bridgelet-sdk commit no longer matches what frontend/lib/create-bridgelet-client.ts ' +
+        'and frontend/lib/bridgelet.ts expect. Update the frontend to match, or point ' +
+        'compatibility.json at a different bridgelet-sdk commit.',
+    );
+    process.exit(1);
+  }
+
+  console.log('\nAll checked endpoints and fields are present.');
+}
+
+main().catch((err) => {
+  console.error('::error::check-sdk-contract.mjs failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #395

## Problem

`bridgelet-core`, `bridgelet-sdk`, and this repo each release independently, and nothing recorded which frontend release actually works against which SDK version, or gave an automated signal when a combination breaks.

## What this adds

- **[`docs/compatibility.md`](docs/compatibility.md)** — the human-readable matrix: which `bridgelet` releases are verified against which `bridgelet-sdk` / `bridgelet-core` versions, a status legend, and the update process.
- **[`compatibility.json`](compatibility.json)** — the machine-readable pin (`verified.bridgeletSdk`/`bridgeletCore`: repo/ref/commit/version) that both CI and the release process read. Currently pinned to `bridgelet-sdk`/`bridgelet-core` `main` by commit SHA, since neither repo has cut a tagged release yet.
- **[`.github/workflows/compatibility.yml`](.github/workflows/compatibility.yml)** — checks out the pinned `bridgelet-sdk` commit, boots it against a real Postgres + Stellar testnet, and runs **[`scripts/check-sdk-contract.mjs`](scripts/check-sdk-contract.mjs)** against its live OpenAPI spec (`GET /api/docs-json`). It fails the build if an endpoint or field `frontend/lib/create-bridgelet-client.ts` depends on is missing — this is the authoritative pass/fail signal, and it runs on every PR (path-filtered) and on a daily schedule **without needing funded-testnet secrets**. When `BRIDGELET_SDK_*` secrets are configured (documented in `docs/compatibility.md#required-ci-secrets`) it additionally runs the `e2e/` Playwright suite in "SDK integration" mode as a best-effort secondary check; without them, it still verifies install/build/migrate/boot and says explicitly in the job summary what was skipped rather than reporting a false pass.
- **[`scripts/check-compatibility-doc.mjs`](scripts/check-compatibility-doc.mjs)**, wired into `.release-it.json`'s `before:git:release` hook — blocks tagging a release until `compatibility.json` and `docs/compatibility.md` have been updated for that version and CI has actually verified the pin (`status: "verified"`). I ran it locally against the current repo state and confirmed it correctly refuses to release right now, since the pin hasn't had a passing CI run yet.
- `README.md`, `CHANGELOG.md`, and `package.json` (`bridgeletCompatibility` pointer + `check:compatibility`/`check:sdk-contract` scripts) updated to reference the above.

## Why not a full-file diff or a pure browser e2e check?

Two things I found while building this that shaped the design, flagged here for visibility:

1. `frontend/lib/bridgelet.ts` is **hand-written**, not the output of `frontend/scripts/generate-types.mjs` (which emits `openapi-typescript`'s `paths`/`components` shape). Regenerating and diffing that file against a live SDK would show a 100% rewrite on every run regardless of real compatibility — a false-positive failure, not a signal. `check-sdk-contract.mjs` instead asserts field-name presence for the specific endpoints/fields the frontend's client actually reads/sends, resolving `$ref`s against the live spec. It's field-presence, not full type/enum equivalence — documented as a known limit in the script's header and in `docs/compatibility.md`.
2. `frontend/components/mock-provider.tsx` currently enables MSW mocking whenever `NODE_ENV=development`, regardless of any `E2E_USE_MOCKS` setting, and `claim-flow.tsx`'s redeem handler has a hardcoded dev-mode stub. So the `e2e/README.md`-documented "SDK integration" mode doesn't yet exercise every route against a real backend end-to-end. I've kept the Playwright run as a secondary, best-effort check (`continue-on-error`, doesn't fail the job) and documented the gap rather than either silently claiming full e2e coverage or expanding this PR's scope into fixing the mock-toggle wiring, which is a separate, pre-existing issue.

I also found, while comparing the frontend's types against `bridgelet-sdk`'s actual DTOs, that the frontend's `AccountStatus` type (`pending | claimed | expired`) doesn't match the SDK's real enum (`pending_payment | pending_claim | claimed | expired | failed`) — a genuine, pre-existing drift. `check-sdk-contract.mjs` deliberately doesn't check enum values (see above), so this doesn't fail CI; it's called out in `docs/compatibility.md#known-gap-this-check-does-not-close` as a known issue for whoever picks it up next, not something this PR fixes.

## Acceptance criteria

- [x] A compatibility matrix exists and is kept current as part of each release — `docs/compatibility.md` + `compatibility.json`, enforced by the release-it hook.
- [x] CI verifies at least one known-good cross-repo combination on each PR or on a scheduled basis — `.github/workflows/compatibility.yml`, PR (path-filtered) + daily schedule + manual dispatch.
- [x] `.release-it.json` release process updated to require the compatibility doc be updated before tagging — `before:git:release` hook, verified locally to correctly block.

## Test plan

- [x] `node scripts/check-compatibility-doc.mjs` run locally — correctly exits non-zero against current repo state (pin not yet CI-verified), with a clear error message.
- [x] `node scripts/check-sdk-contract.mjs` unit-tested locally against a mock OpenAPI server built from `bridgelet-sdk`'s actual DTOs (pulled from the real repo) — passes on a matching spec, fails with a precise message when a depended-on field is removed.
- [x] `.github/workflows/compatibility.yml` validated for YAML syntax; steps cross-checked against `bridgelet-sdk`'s actual `.env.example`, `main.ts` bootstrap (network-guard, Swagger path, port), and `health` controller — I don't have a way to execute a full Postgres+Stellar-testnet run of `bridgelet-sdk` from here, so the first real CI run may surface small environment fixes.
- [ ] First live run of `.github/workflows/compatibility.yml` on this PR (will run automatically since this PR touches `compatibility.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)