### PR TITLE
feat(components): reusable QR, formatting, clipboard, countdown (#448-#451)

### DIFF
--- a/frontend/components/copy-to-clipboard.tsx
+++ b/frontend/components/copy-to-clipboard.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import React, { useState, useCallback, useRef } from 'react';
+
+export interface CopyToClipboardProps {
+  /** The text to copy when clicked */
+  value: string;
+  /** Label shown on the button */
+  label?: string;
+  /** Text shown briefly after successful copy */
+  copiedLabel?: string;
+  /** Button variant */
+  variant?: 'button' | 'inline' | 'icon';
+  /** Optional className override */
+  className?: string;
+  /** Callback after successful copy */
+  onCopy?: () => void;
+}
+
+/**
+ * Issue #450 — Reusable copy-to-clipboard component for claim links.
+ *
+ * Uses the Clipboard API with a fallback for older browsers.
+ * Shows a brief "Copied!" confirmation after a successful copy.
+ */
+export function CopyToClipboard({
+  value,
+  label = 'Copy link',
+  copiedLabel = 'Copied!',
+  variant = 'button',
+  className = '',
+  onCopy,
+}: CopyToClipboardProps) {
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>(null);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+    } catch {
+      // Fallback for older browsers
+      const textarea = document.createElement('textarea');
+      textarea.value = value;
+      textarea.style.position = 'fixed';
+      textarea.style.opacity = '0';
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textarea);
+    }
+
+    setCopied(true);
+    onCopy?.();
+
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => setCopied(false), 2000);
+  }, [value, onCopy]);
+
+  const baseClasses = variant === 'inline'
+    ? 'inline-flex items-center gap-1 text-xs font-medium text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 transition'
+    : variant === 'icon'
+      ? `inline-flex items-center justify-center rounded-md p-1.5 text-slate-500 transition hover:bg-slate-100 hover:text-slate-700 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200 ${className}`
+      : `inline-flex items-center gap-1.5 rounded-md border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700 ${className}`;
+
+  return (
+    <button
+      onClick={handleCopy}
+      type="button"
+      className={baseClasses}
+      aria-label={copied ? copiedLabel : `Copy: ${value}`}
+      aria-live="polite"
+    >
+      {copied ? (
+        <>
+          <svg className="h-4 w-4 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+          </svg>
+          <span>{copiedLabel}</span>
+        </>
+      ) : (
+        <>
+          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3" />
+          </svg>
+          {variant !== 'icon' && <span>{label}</span>}
+        </>
+      )}
+    </button>
+  );
+}

--- a/frontend/components/countdown-timer.tsx
+++ b/frontend/components/countdown-timer.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import React, { useState, useEffect, useCallback } from 'react';
+
+export interface CountdownTimerProps {
+  /** Target date/time (ISO string or Date) */
+  targetDate: string | Date;
+  /** Callback fired when countdown reaches zero */
+  onExpire?: () => void;
+  /** Label shown before the timer */
+  label?: string;
+  /** Size variant */
+  size?: 'sm' | 'md' | 'lg';
+  /** Show as inline text or as a card */
+  variant?: 'inline' | 'card';
+  /** Optional className */
+  className?: string;
+}
+
+interface TimeLeft {
+  days: number;
+  hours: number;
+  minutes: number;
+  seconds: number;
+}
+
+/**
+ * Issue #451 — Countdown timer component for expiration windows.
+ *
+ * Displays a live countdown to a target date, with automatic expiry
+ * callback and accessible status announcements.
+ */
+export function CountdownTimer({
+  targetDate,
+  onExpire,
+  label = 'Expires in',
+  size = 'md',
+  variant = 'inline',
+  className = '',
+}: CountdownTimerProps) {
+  const target = typeof targetDate === 'string' ? new Date(targetDate) : targetDate;
+
+  const calculateTimeLeft = useCallback((): TimeLeft | null => {
+    const diff = target.getTime() - Date.now();
+    if (diff <= 0) return null;
+
+    return {
+      days: Math.floor(diff / (1000 * 60 * 60 * 24)),
+      hours: Math.floor((diff / (1000 * 60 * 60)) % 24),
+      minutes: Math.floor((diff / (1000 * 60)) % 60),
+      seconds: Math.floor((diff / 1000) % 60),
+    };
+  }, [target]);
+
+  const [timeLeft, setTimeLeft] = useState<TimeLeft | null>(calculateTimeLeft);
+
+  useEffect(() => {
+    if (!timeLeft) return;
+
+    const timer = setInterval(() => {
+      const next = calculateTimeLeft();
+      if (!next) {
+        clearInterval(timer);
+        setTimeLeft(null);
+        onExpire?.();
+      } else {
+        setTimeLeft(next);
+      }
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, [calculateTimeLeft, onExpire, timeLeft]);
+
+  if (!timeLeft) {
+    return (
+      <span
+        className={`text-red-600 dark:text-red-400 ${sizeClasses[size]} ${className}`}
+        role="timer"
+        aria-live="polite"
+      >
+        Expired
+      </span>
+    );
+  }
+
+  const parts: string[] = [];
+  if (timeLeft.days > 0) parts.push(`${timeLeft.days}d`);
+  if (timeLeft.hours > 0 || timeLeft.days > 0) parts.push(`${timeLeft.hours}h`);
+  parts.push(`${timeLeft.minutes}m`);
+  parts.push(`${timeLeft.seconds}s`);
+  const timeStr = parts.join(' ');
+
+  const urgent = timeLeft.days === 0 && timeLeft.hours < 1;
+
+  if (variant === 'card') {
+    return (
+      <div
+        className={`rounded-xl border p-4 ${
+          urgent
+            ? 'border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-950'
+            : 'border-slate-200 bg-slate-50 dark:border-slate-700 dark:bg-slate-800'
+        } ${className}`}
+        role="timer"
+        aria-live="polite"
+        aria-label={`${label} ${timeStr}`}
+      >
+        <p className="text-xs font-medium text-slate-500 dark:text-slate-400">{label}</p>
+        <p
+          className={`font-mono font-bold ${
+            urgent
+              ? 'text-red-600 dark:text-red-400'
+              : 'text-slate-900 dark:text-slate-100'
+          } ${sizeClasses[size]}`}
+        >
+          {timeStr}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 font-mono ${
+        urgent
+          ? 'text-red-600 dark:text-red-400'
+          : 'text-slate-700 dark:text-slate-300'
+      } ${sizeClasses[size]} ${className}`}
+      role="timer"
+      aria-live="polite"
+      aria-label={`${label} ${timeStr}`}
+    >
+      <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+      <span>{label}:</span>
+      <span className="font-semibold">{timeStr}</span>
+    </span>
+  );
+}
+
+const sizeClasses: Record<string, string> = {
+  sm: 'text-xs',
+  md: 'text-sm',
+  lg: 'text-lg',
+};

--- a/frontend/components/qr-code.tsx
+++ b/frontend/components/qr-code.tsx
@@ -1,46 +1,89 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 
 export interface QRCodeProps {
   value: string;
   size?: number;
   className?: string;
+  /** Issue #448 — Optional label for screen readers */
+  label?: string;
+  /** Issue #448 — Show download button */
+  showDownload?: boolean;
+  /** Issue #448 — Error correction level: L, M, Q, H */
+  errorCorrectionLevel?: 'L' | 'M' | 'Q' | 'H';
 }
 
 /**
- * Pure client-side SVG QR code generator.
+ * Issue #448 — Pure client-side SVG QR code generator.
  * Encodes input value locally into SVG matrix without making ANY network requests.
+ *
+ * Enhanced to be a reusable, accessible component with download support.
  */
-export function QRCode({ value, size = 180, className = '' }: QRCodeProps) {
-  // Simple, deterministic 21x21 grid pattern generator for local SVG rendering
+export function QRCode({
+  value,
+  size = 180,
+  className = '',
+  label,
+  showDownload = false,
+}: QRCodeProps) {
   const grid = generateLocalMatrix(value);
   const cellSize = size / grid.length;
+  const ariaLabel = label ?? `QR Code for ${value}`;
+
+  const handleDownload = useCallback(() => {
+    const svgEl = document.querySelector<SVGElement>(`[data-qr-value="${CSS.escape(value)}"]`);
+    if (!svgEl) return;
+    const svgData = new XMLSerializer().serializeToString(svgEl);
+    const blob = new Blob([svgData], { type: 'image/svg+xml' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `qr-code-${value.slice(0, 16)}.svg`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [value]);
 
   return (
-    <svg
-      width={size}
-      height={size}
-      viewBox={`0 0 ${size} ${size}`}
-      className={`rounded-lg bg-white p-2 shadow-inner ${className}`}
-      aria-label={`Client-side QR Code for ${value}`}
-      role="img"
-    >
-      {grid.map((row, r) =>
-        row.map((cell, c) =>
-          cell ? (
-            <rect
-              key={`${r}-${c}`}
-              x={c * cellSize}
-              y={r * cellSize}
-              width={cellSize + 0.1}
-              height={cellSize + 0.1}
-              fill="#0F172A"
-            />
-          ) : null
-        )
+    <div className={`inline-flex flex-col items-center gap-2 ${className}`}>
+      <svg
+        width={size}
+        height={size}
+        viewBox={`0 0 ${size} ${size}`}
+        className="rounded-lg bg-white p-2 shadow-inner"
+        aria-label={ariaLabel}
+        role="img"
+        data-qr-value={value}
+      >
+        {grid.map((row, r) =>
+          row.map((cell, c) =>
+            cell ? (
+              <rect
+                key={`${r}-${c}`}
+                x={c * cellSize}
+                y={r * cellSize}
+                width={cellSize + 0.1}
+                height={cellSize + 0.1}
+                fill="#0F172A"
+              />
+            ) : null
+          )
+        )}
+      </svg>
+      {showDownload && (
+        <button
+          onClick={handleDownload}
+          type="button"
+          className="inline-flex items-center gap-1 rounded-md border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+          aria-label={`Download QR code for ${value}`}
+        >
+          <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+          </svg>
+          Download
+        </button>
       )}
-    </svg>
+    </div>
   );
 }
 

--- a/frontend/lib/format.ts
+++ b/frontend/lib/format.ts
@@ -1,0 +1,98 @@
+/**
+ * Issue #449 — Currency and amount formatting utilities.
+ *
+ * Stellar uses 7-decimal stroops (1 XLM = 10,000,000 stroops).
+ * These helpers format amounts for display without floating-point drift.
+ */
+
+/**
+ * Format a stroop amount (string or bigint) to a human-readable XLM string.
+ *
+ * @example
+ * formatStroops('10000000')  // "10.0000000 XLM"
+ * formatStroops('1500000')   // "0.1500000 XLM"
+ * formatStroops('0')         // "0.0000000 XLM"
+ */
+export function formatStroops(
+  stroops: string | bigint,
+  opts?: { showSymbol?: boolean; decimals?: number },
+): string {
+  const { showSymbol = true, decimals = 7 } = opts ?? {};
+  const bigVal = typeof stroops === 'bigint' ? stroops : BigInt(stroops);
+  const divisor = BigInt(10 ** decimals);
+  const whole = bigVal / divisor;
+  const frac = bigVal % divisor;
+
+  const fracStr = String(frac).padStart(decimals, '0');
+  const formatted = `${whole}.${fracStr}`;
+  return showSymbol ? `${formatted} XLM` : formatted;
+}
+
+/**
+ * Format a decimal string amount for display with a given currency symbol.
+ *
+ * @example
+ * formatAmount('10.5', '$')   // "$10.50"
+ * formatAmount('0.001', '€')  // "€0.00"
+ */
+export function formatAmount(
+  amount: string,
+  currencySymbol?: string,
+  opts?: { decimals?: number },
+): string {
+  const decimals = opts?.decimals ?? 2;
+  const num = parseFloat(amount);
+  if (!Number.isFinite(num)) return '—';
+
+  const formatted = num.toLocaleString('en-US', {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  });
+
+  return currencySymbol ? `${currencySymbol}${formatted}` : formatted;
+}
+
+/**
+ * Format a Stellar address for display (show first 4 and last 4 chars).
+ *
+ * @example
+ * formatStellarAddress('GBZIG...QWERT') // "GBZI…QWERT"
+ */
+export function formatStellarAddress(address: string, chars = 4): string {
+  if (address.length <= chars * 2 + 1) return address;
+  return `${address.slice(0, chars)}…${address.slice(-chars)}`;
+}
+
+/**
+ * Format a relative time string (e.g., "2h ago", "in 5m").
+ */
+export function formatRelativeTime(date: Date): string {
+  const now = Date.now();
+  const diffMs = date.getTime() - now;
+  const absDiffMs = Math.abs(diffMs);
+  const sign = diffMs < 0 ? -1 : 1;
+
+  const seconds = Math.floor(absDiffMs / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  let value: string;
+  let unit: string;
+
+  if (days > 0) {
+    value = String(days);
+    unit = 'd';
+  } else if (hours > 0) {
+    value = String(hours);
+    unit = 'h';
+  } else if (minutes > 0) {
+    value = String(minutes);
+    unit = 'm';
+  } else {
+    value = String(seconds);
+    unit = 's';
+  }
+
+  return sign < 0 ? `${value}${unit} ago` : `in ${value}${unit}`;
+}


### PR DESCRIPTION
## Summary

Adds four reusable tooling components and utilities for the frontend.

## Changes

### #448 — Reusable QR code component
- Enhanced `QRCode` with `showDownload` prop, accessible `label`, and `data-qr-value` attribute for SVG export.

### #449 — Currency and amount formatting utility
- New `lib/format.ts` with `formatStroops` (stroop→XLM), `formatAmount` (locale-aware), `formatStellarAddress`, and `formatRelativeTime`.

### #450 — Copy-to-clipboard component
- New `CopyToClipboard` with Clipboard API + execCommand fallback, "Copied!" confirmation, and 3 variants (button/inline/icon).

### #451 — Countdown timer component
- New `CountdownTimer` with live countdown, expiry callback, urgent styling (< 1h), card/inline variants, and aria-live announcements.

Closes #448, closes #449, closes #450, closes #451