### PR TITLE
Mobile: localization, Detox E2E, CI pipeline, app store checklist (#484 #485 #486 #487)

### DIFF
--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -1,0 +1,274 @@
+name: Mobile CI
+
+# Issue #486: Mobile CI build and test pipeline
+# Runs on any PR that touches mobile/ and builds installable artifacts for
+# both iOS and Android (debug builds). Wired to run the Detox E2E suite.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'mobile/**'
+      - '.github/workflows/mobile-ci.yml'
+  pull_request:
+    paths:
+      - 'mobile/**'
+      - '.github/workflows/mobile-ci.yml'
+
+concurrency:
+  group: mobile-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20'
+
+jobs:
+  # ── Lint & type-check ────────────────────────────────────────────────────────
+  lint:
+    name: Lint & Type Check
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mobile
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: mobile/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint --if-present
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+  # ── Unit tests ───────────────────────────────────────────────────────────────
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mobile
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: mobile/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm test -- --ci --coverage --passWithNoTests
+
+      - name: Upload coverage
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: mobile-coverage
+          path: mobile/coverage/
+
+  # ── Android build ────────────────────────────────────────────────────────────
+  build-android:
+    name: Android Debug Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mobile
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: mobile/package-lock.json
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ hashFiles('mobile/android/**/*.gradle*', 'mobile/android/gradle-wrapper.properties') }}
+          restore-keys: gradle-
+
+      - name: Build Android debug APK
+        run: |
+          cd android
+          ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug --no-daemon
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-debug-apk
+          path: mobile/android/app/build/outputs/apk/debug/app-debug.apk
+          retention-days: 7
+
+  # ── iOS build ────────────────────────────────────────────────────────────────
+  build-ios:
+    name: iOS Debug Build
+    runs-on: macos-14
+    defaults:
+      run:
+        working-directory: mobile
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: mobile/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install CocoaPods
+        run: |
+          cd ios
+          pod install --repo-update
+
+      - name: Cache DerivedData
+        uses: actions/cache@v4
+        with:
+          path: mobile/ios/build
+          key: ios-derived-${{ hashFiles('mobile/ios/Podfile.lock') }}
+          restore-keys: ios-derived-
+
+      - name: Build iOS debug app
+        run: |
+          xcodebuild \
+            -workspace ios/Bridgelet.xcworkspace \
+            -scheme Bridgelet \
+            -configuration Debug \
+            -sdk iphonesimulator \
+            -derivedDataPath ios/build \
+            -destination 'platform=iOS Simulator,name=iPhone 15' \
+            build \
+            | xcpretty
+
+      - name: Upload .app artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-debug-app
+          path: mobile/ios/build/Build/Products/Debug-iphonesimulator/Bridgelet.app
+          retention-days: 7
+
+  # ── Detox E2E — Android ──────────────────────────────────────────────────────
+  e2e-android:
+    name: Detox E2E (Android)
+    runs-on: ubuntu-latest
+    needs: [build-android]
+    defaults:
+      run:
+        working-directory: mobile
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: mobile/package-lock.json
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Enable KVM (Android emulator acceleration)
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          target: google_apis
+          arch: x86_64
+          profile: pixel_7
+          script: echo "Emulator started"
+
+      - name: Download APK artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: android-debug-apk
+          path: mobile/android/app/build/outputs/apk/debug/
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Detox E2E (Android)
+        run: npx detox test --configuration android.emu.debug --headless
+
+      - name: Upload E2E artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: detox-android-artifacts
+          path: mobile/artifacts/
+
+  # ── Detox E2E — iOS ──────────────────────────────────────────────────────────
+  e2e-ios:
+    name: Detox E2E (iOS)
+    runs-on: macos-14
+    needs: [build-ios]
+    defaults:
+      run:
+        working-directory: mobile
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: mobile/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download iOS .app artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ios-debug-app
+          path: mobile/ios/build/Build/Products/Debug-iphonesimulator/Bridgelet.app
+
+      - name: Boot iPhone 15 simulator
+        run: |
+          xcrun simctl boot "iPhone 15" || true
+
+      - name: Run Detox E2E (iOS)
+        run: npx detox test --configuration ios.sim.debug
+
+      - name: Upload E2E artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: detox-ios-artifacts
+          path: mobile/artifacts/

--- a/mobile/.detoxrc.js
+++ b/mobile/.detoxrc.js
@@ -1,0 +1,50 @@
+/** @type {Detox.DetoxConfig} */
+module.exports = {
+  testRunner: {
+    args: {
+      $0: 'jest',
+      config: 'e2e/jest.config.js',
+    },
+    jest: {
+      setupTimeout: 120000,
+    },
+  },
+  apps: {
+    'ios.debug': {
+      type: 'ios.app',
+      binaryPath: 'ios/build/Build/Products/Debug-iphonesimulator/Bridgelet.app',
+      build:
+        'xcodebuild -workspace ios/Bridgelet.xcworkspace -scheme Bridgelet -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build',
+    },
+    'android.debug': {
+      type: 'android.apk',
+      binaryPath: 'android/app/build/outputs/apk/debug/app-debug.apk',
+      build:
+        'cd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug',
+    },
+  },
+  devices: {
+    simulator: {
+      type: 'ios.simulator',
+      device: {
+        type: 'iPhone 15',
+      },
+    },
+    emulator: {
+      type: 'android.emulator',
+      device: {
+        avdName: 'Pixel_7_API_34',
+      },
+    },
+  },
+  configurations: {
+    'ios.sim.debug': {
+      device: 'simulator',
+      app: 'ios.debug',
+    },
+    'android.emu.debug': {
+      device: 'emulator',
+      app: 'android.debug',
+    },
+  },
+};

--- a/mobile/APP_STORE_RELEASE.md
+++ b/mobile/APP_STORE_RELEASE.md
@@ -1,0 +1,236 @@
+# App Store Release Checklist
+
+> **Location:** `mobile/APP_STORE_RELEASE.md`
+> **Issue #487:** Mobile app store release checklist and metadata
+>
+> This document covers all requirements for submitting Bridgelet to the
+> Apple App Store and Google Play Store. Update and check off each item
+> before every release. Version this file alongside the app source.
+
+---
+
+## Table of Contents
+
+1. [Pre-Release Checklist](#pre-release-checklist)
+2. [Apple App Store Requirements](#apple-app-store-requirements)
+3. [Google Play Store Requirements](#google-play-store-requirements)
+4. [Privacy Labels & Data Collection Disclosure](#privacy-labels--data-collection-disclosure)
+5. [Screenshot Specifications](#screenshot-specifications)
+6. [App Description](#app-description)
+7. [Release Notes Template](#release-notes-template)
+
+---
+
+## Pre-Release Checklist
+
+### Code & Build
+
+- [ ] All unit tests pass (`npm test`)
+- [ ] Detox E2E suite passes on both iOS and Android simulators
+- [ ] No critical lint warnings (`npm run lint`)
+- [ ] TypeScript compiles without errors (`npx tsc --noEmit`)
+- [ ] Version number bumped in `app.json` (`version` and `ios.buildNumber` / `android.versionCode`)
+- [ ] `CHANGELOG.md` updated with release notes
+- [ ] Environment variables confirmed for production (`EXPO_PUBLIC_API_URL`, etc.)
+- [ ] Sentry / crash reporting DSN points to production project
+
+### Security
+
+- [ ] No hardcoded secrets, keys, or test credentials in source
+- [ ] Certificate pinning active for production API calls
+- [ ] Biometric / PIN auth tested on physical devices
+- [ ] Wallet backup warning reviewed and accurate
+
+### Accessibility
+
+- [ ] VoiceOver (iOS) and TalkBack (Android) tested on main flows
+- [ ] Minimum touch target size (44×44 pt) verified on all interactive elements
+- [ ] Dynamic Type / large-font tested on claim and send screens
+
+---
+
+## Apple App Store Requirements
+
+### Account & Legal
+
+- [ ] Apple Developer Program membership active
+- [ ] App ID registered in App Store Connect
+- [ ] Certificates and provisioning profiles up to date
+- [ ] Export Compliance information completed (app uses HTTPS/TLS — exempt from BIS encryption)
+- [ ] Age Rating questionnaire completed (12+)
+
+### App Metadata
+
+| Field | Value |
+|-------|-------|
+| **App Name** | Bridgelet |
+| **Subtitle** | Stellar payments, simplified |
+| **Category (Primary)** | Finance |
+| **Category (Secondary)** | Utilities |
+| **Age Rating** | 12+ |
+| **Copyright** | © 2026 Bridgelet |
+| **Support URL** | https://bridgelet.org/support |
+| **Marketing URL** | https://bridgelet.org |
+| **Privacy Policy URL** | https://bridgelet.org/privacy |
+
+### Build
+
+- [ ] Release build signed with Distribution certificate
+- [ ] Bitcode disabled (React Native default)
+- [ ] `NSCameraUsageDescription` set (QR scanner)
+- [ ] `NSFaceIDUsageDescription` set (biometric auth)
+- [ ] `NSPhotoLibraryUsageDescription` set if applicable
+- [ ] All required device capabilities declared in `Info.plist`
+
+---
+
+## Google Play Store Requirements
+
+### Account & Legal
+
+- [ ] Google Play Developer account active
+- [ ] App signing key stored securely (Google Play App Signing enrolled)
+- [ ] Data Safety form completed (see Privacy section below)
+- [ ] Target API level ≥ 34 (Android 14) for new submissions
+
+### App Metadata
+
+| Field | Value |
+|-------|-------|
+| **App Name** | Bridgelet |
+| **Short Description** | Send and receive Stellar payments instantly |
+| **Category** | Finance |
+| **Content Rating** | Everyone |
+| **Email** | support@bridgelet.org |
+| **Privacy Policy URL** | https://bridgelet.org/privacy |
+
+### Build
+
+- [ ] Release AAB signed with upload key
+- [ ] `minSdkVersion` ≥ 24 (Android 7.0)
+- [ ] `targetSdkVersion` = 34
+- [ ] `CAMERA` permission declared (QR scanner)
+- [ ] `USE_BIOMETRIC` and `USE_FINGERPRINT` permissions declared
+- [ ] `INTERNET` permission declared
+- [ ] ProGuard / R8 rules reviewed to avoid stripping required classes
+
+---
+
+## Privacy Labels & Data Collection Disclosure
+
+Bridgelet is designed with minimal data collection. The following reflects
+what the app **actually** collects as of this release.
+
+### Apple App Store — Privacy Nutrition Labels
+
+| Data Type | Collected | Linked to Identity | Used for Tracking |
+|-----------|-----------|-------------------|-------------------|
+| Financial Info (wallet balance, transaction history) | No — stored on Stellar blockchain, not by Bridgelet | — | No |
+| User ID (Stellar public key) | Yes | No — pseudonymous | No |
+| Crash Data | Yes (opt-in via Sentry) | No | No |
+| Diagnostics / Performance data | Yes (aggregated, anonymised) | No | No |
+| Contact Info (email for support) | Optional, only if user contacts support | No | No |
+
+**No data sold to third parties.**
+**No data used for advertising or marketing.**
+
+### Google Play — Data Safety Form
+
+| Data Type | Collected | Shared | Purpose |
+|-----------|-----------|--------|---------|
+| Stellar public key | Yes | No | App functionality |
+| Crash logs | Yes (opt-in) | With Sentry (processor) | App stability |
+| App interactions | Yes (anonymised) | No | Analytics / improvement |
+| Financial transactions | No — all transactions go directly on-chain | — | — |
+
+Users can delete their local data by uninstalling the app.
+Wallet keys are stored locally using device-encrypted storage (Expo SecureStore).
+
+---
+
+## Screenshot Specifications
+
+Prepare the following screenshots (light and dark variants recommended):
+
+### iOS
+
+| Device | Dimensions | Required |
+|--------|-----------|----------|
+| iPhone 6.7" (15 Pro Max) | 1290 × 2796 px | ✅ Required |
+| iPhone 6.5" (14 Plus) | 1242 × 2688 px | ✅ Required |
+| iPhone 5.5" (8 Plus) | 1242 × 2208 px | ✅ Required |
+| iPad Pro 12.9" (6th gen) | 2048 × 2732 px | Required if iPad supported |
+
+### Android
+
+| Type | Dimensions |
+|------|-----------|
+| Phone | 1080 × 1920 px (min) |
+| 7" Tablet | 1200 × 1920 px |
+| 10" Tablet | 1920 × 1200 px |
+
+### Required Screens to Capture
+
+- [ ] Onboarding / welcome screen
+- [ ] Claim screen with QR scanner prompt
+- [ ] Claim success screen showing amount received
+- [ ] Send screen with recipient and amount
+- [ ] Send review / confirmation screen
+- [ ] Home / wallet balance screen
+- [ ] Settings screen
+
+---
+
+## App Description
+
+### Short Description (80 chars max — Google Play)
+
+```
+Send and receive Stellar payments via shareable claim links.
+```
+
+### Full Description
+
+```
+Bridgelet makes Stellar payments accessible to everyone — no prior crypto
+knowledge required.
+
+SEND PAYMENTS
+Create a secure payment link and share it via any messaging app, email, or
+QR code. Recipients claim funds directly to their Stellar wallet.
+
+CLAIM PAYMENTS
+Receive a Bridgelet link? Tap to claim — we guide you through setting up
+a wallet if you don't have one yet.
+
+BUILT ON STELLAR
+Every transaction settles in seconds on the Stellar network with near-zero
+fees. No intermediaries, no custodians.
+
+SECURE BY DESIGN
+• Keys stored in device-encrypted storage
+• Optional biometric authentication
+• Open-source — audit the code yourself
+
+PRIVATE
+Bridgelet does not store your private keys or transaction history.
+All payment data lives on the Stellar blockchain.
+```
+
+---
+
+## Release Notes Template
+
+```
+Version X.Y.Z
+
+What's new:
+• [Describe key user-facing changes]
+• [Bug fixes and performance improvements]
+
+Full changelog: https://github.com/bridgelet-org/bridgelet/blob/main/CHANGELOG.md
+```
+
+---
+
+*Last updated: 2026-08-26 — update this date and version with each release.*

--- a/mobile/app/src/i18n/index.ts
+++ b/mobile/app/src/i18n/index.ts
@@ -1,0 +1,128 @@
+/**
+ * i18n/index.ts
+ *
+ * Issue #484: Mobile app localization
+ *
+ * Sets up i18next with:
+ *  - Device locale detection via expo-localization
+ *  - AsyncStorage persistence for manual language override
+ *  - English (en), Spanish (es), and French (fr) locale bundles
+ *  - Interpolation for dynamic values ({{amount}}, {{asset}}, etc.)
+ *
+ * Usage:
+ *   import { t } from '@/i18n';
+ *   t('claim.title')
+ *   t('claim.successMessage', { amount: '10', asset: 'USDC' })
+ *
+ * Changing language at runtime:
+ *   import { changeLanguage } from '@/i18n';
+ *   await changeLanguage('es');
+ */
+
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import * as Localization from 'expo-localization';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import en from './locales/en.json';
+import es from './locales/es.json';
+import fr from './locales/fr.json';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+export const SUPPORTED_LANGUAGES = ['en', 'es', 'fr'] as const;
+export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
+
+export const LANGUAGE_NAMES: Record<SupportedLanguage, string> = {
+  en: 'English',
+  es: 'Español',
+  fr: 'Français',
+};
+
+const LANGUAGE_STORAGE_KEY = '@bridgelet:language';
+const DEFAULT_LANGUAGE: SupportedLanguage = 'en';
+
+// ─── Locale resolution ────────────────────────────────────────────────────────
+
+/**
+ * Detect the device locale and return the closest supported language.
+ * Falls back to DEFAULT_LANGUAGE when no match is found.
+ */
+function detectDeviceLanguage(): SupportedLanguage {
+  const locales = Localization.getLocales();
+  for (const locale of locales) {
+    const lang = locale.languageCode?.toLowerCase() as SupportedLanguage | undefined;
+    if (lang && SUPPORTED_LANGUAGES.includes(lang)) {
+      return lang;
+    }
+  }
+  return DEFAULT_LANGUAGE;
+}
+
+/**
+ * Load the persisted language preference from AsyncStorage.
+ * Returns null when no preference has been saved.
+ */
+async function loadPersistedLanguage(): Promise<SupportedLanguage | null> {
+  try {
+    const stored = await AsyncStorage.getItem(LANGUAGE_STORAGE_KEY);
+    if (stored && SUPPORTED_LANGUAGES.includes(stored as SupportedLanguage)) {
+      return stored as SupportedLanguage;
+    }
+  } catch {
+    // Storage unavailable — proceed with device detection
+  }
+  return null;
+}
+
+// ─── Initialisation ───────────────────────────────────────────────────────────
+
+/**
+ * Initialise i18next.  Call this once at app startup (e.g. in _layout.tsx)
+ * and await the returned promise before rendering any translated strings.
+ */
+export async function initI18n(): Promise<void> {
+  const persisted = await loadPersistedLanguage();
+  const deviceLang = detectDeviceLanguage();
+  const lng = persisted ?? deviceLang;
+
+  await i18n
+    .use(initReactI18next)
+    .init({
+      resources: {
+        en: { translation: en },
+        es: { translation: es },
+        fr: { translation: fr },
+      },
+      lng,
+      fallbackLng: DEFAULT_LANGUAGE,
+      interpolation: {
+        escapeValue: false, // React Native handles XSS
+      },
+      compatibilityJSON: 'v3',
+    });
+}
+
+/**
+ * Change the active language and persist the choice so it survives restarts.
+ */
+export async function changeLanguage(lang: SupportedLanguage): Promise<void> {
+  await i18n.changeLanguage(lang);
+  try {
+    await AsyncStorage.setItem(LANGUAGE_STORAGE_KEY, lang);
+  } catch {
+    // Non-fatal — preference simply won't persist across restarts
+  }
+}
+
+/**
+ * Return the currently active language code.
+ */
+export function getCurrentLanguage(): SupportedLanguage {
+  const lang = i18n.language as SupportedLanguage;
+  return SUPPORTED_LANGUAGES.includes(lang) ? lang : DEFAULT_LANGUAGE;
+}
+
+// Re-export the i18next translate function for convenience
+export const t = i18n.t.bind(i18n);
+export default i18n;

--- a/mobile/app/src/i18n/locales/en.json
+++ b/mobile/app/src/i18n/locales/en.json
@@ -1,0 +1,85 @@
+{
+  "common": {
+    "loading": "Loading…",
+    "error": "Something went wrong",
+    "retry": "Retry",
+    "cancel": "Cancel",
+    "confirm": "Confirm",
+    "close": "Close",
+    "back": "Back",
+    "next": "Next",
+    "done": "Done",
+    "save": "Save",
+    "copy": "Copy",
+    "copied": "Copied!",
+    "share": "Share"
+  },
+  "onboarding": {
+    "title": "Welcome to Bridgelet",
+    "subtitle": "Send and receive Stellar payments anywhere, instantly.",
+    "getStarted": "Get Started",
+    "alreadyHaveWallet": "I already have a wallet"
+  },
+  "claim": {
+    "title": "Claim Payment",
+    "subtitle": "Scan or enter a Bridgelet claim code to receive funds.",
+    "inputLabel": "Claim Code",
+    "inputPlaceholder": "Enter or paste your claim code",
+    "scanQr": "Scan QR Code",
+    "claimButton": "Claim Funds",
+    "claiming": "Claiming…",
+    "successTitle": "Payment Claimed!",
+    "successMessage": "{{amount}} {{asset}} has been added to your wallet.",
+    "errorInvalid": "Invalid or expired claim code.",
+    "errorAlreadyClaimed": "This payment has already been claimed.",
+    "newWalletPrompt": "No wallet yet? We'll create one for you.",
+    "existingWalletPrompt": "Claim to your existing wallet."
+  },
+  "send": {
+    "title": "Send Payment",
+    "recipientLabel": "Recipient",
+    "recipientPlaceholder": "Stellar address or Bridgelet ID",
+    "amountLabel": "Amount",
+    "amountPlaceholder": "0.00",
+    "assetLabel": "Asset",
+    "memoLabel": "Memo (optional)",
+    "memoPlaceholder": "Add a note",
+    "sendButton": "Send",
+    "sending": "Sending…",
+    "successTitle": "Payment Sent!",
+    "successMessage": "{{amount}} {{asset}} sent to {{recipient}}.",
+    "errorInsufficientFunds": "Insufficient funds.",
+    "errorInvalidAddress": "Invalid recipient address.",
+    "reviewTitle": "Review Payment",
+    "fee": "Network fee"
+  },
+  "wallet": {
+    "balance": "Balance",
+    "address": "Your Address",
+    "noBalance": "No balance yet",
+    "assets": "Assets",
+    "history": "Transaction History",
+    "noHistory": "No transactions yet"
+  },
+  "settings": {
+    "title": "Settings",
+    "language": "Language",
+    "theme": "Theme",
+    "security": "Security",
+    "about": "About",
+    "version": "Version {{version}}",
+    "logout": "Log Out"
+  },
+  "security": {
+    "title": "Security",
+    "biometrics": "Use Biometrics",
+    "pin": "Set PIN",
+    "backup": "Backup Wallet",
+    "backupWarning": "Store your recovery phrase somewhere safe. Anyone with it can access your funds."
+  },
+  "errors": {
+    "networkError": "Network error. Please check your connection.",
+    "timeout": "Request timed out. Please try again.",
+    "unknown": "An unexpected error occurred."
+  }
+}

--- a/mobile/app/src/i18n/locales/es.json
+++ b/mobile/app/src/i18n/locales/es.json
@@ -1,0 +1,85 @@
+{
+  "common": {
+    "loading": "Cargando…",
+    "error": "Algo salió mal",
+    "retry": "Reintentar",
+    "cancel": "Cancelar",
+    "confirm": "Confirmar",
+    "close": "Cerrar",
+    "back": "Atrás",
+    "next": "Siguiente",
+    "done": "Listo",
+    "save": "Guardar",
+    "copy": "Copiar",
+    "copied": "¡Copiado!",
+    "share": "Compartir"
+  },
+  "onboarding": {
+    "title": "Bienvenido a Bridgelet",
+    "subtitle": "Envía y recibe pagos Stellar en cualquier lugar, al instante.",
+    "getStarted": "Comenzar",
+    "alreadyHaveWallet": "Ya tengo una billetera"
+  },
+  "claim": {
+    "title": "Reclamar Pago",
+    "subtitle": "Escanea o ingresa un código de reclamación de Bridgelet para recibir fondos.",
+    "inputLabel": "Código de Reclamación",
+    "inputPlaceholder": "Ingresa o pega tu código de reclamación",
+    "scanQr": "Escanear código QR",
+    "claimButton": "Reclamar Fondos",
+    "claiming": "Reclamando…",
+    "successTitle": "¡Pago Reclamado!",
+    "successMessage": "{{amount}} {{asset}} se ha añadido a tu billetera.",
+    "errorInvalid": "Código de reclamación inválido o expirado.",
+    "errorAlreadyClaimed": "Este pago ya fue reclamado.",
+    "newWalletPrompt": "¿Sin billetera? Te crearemos una.",
+    "existingWalletPrompt": "Reclama en tu billetera existente."
+  },
+  "send": {
+    "title": "Enviar Pago",
+    "recipientLabel": "Destinatario",
+    "recipientPlaceholder": "Dirección Stellar o ID de Bridgelet",
+    "amountLabel": "Monto",
+    "amountPlaceholder": "0.00",
+    "assetLabel": "Activo",
+    "memoLabel": "Nota (opcional)",
+    "memoPlaceholder": "Añade una nota",
+    "sendButton": "Enviar",
+    "sending": "Enviando…",
+    "successTitle": "¡Pago Enviado!",
+    "successMessage": "{{amount}} {{asset}} enviado a {{recipient}}.",
+    "errorInsufficientFunds": "Fondos insuficientes.",
+    "errorInvalidAddress": "Dirección de destinatario inválida.",
+    "reviewTitle": "Revisar Pago",
+    "fee": "Comisión de red"
+  },
+  "wallet": {
+    "balance": "Saldo",
+    "address": "Tu Dirección",
+    "noBalance": "Sin saldo aún",
+    "assets": "Activos",
+    "history": "Historial de Transacciones",
+    "noHistory": "Sin transacciones aún"
+  },
+  "settings": {
+    "title": "Configuración",
+    "language": "Idioma",
+    "theme": "Tema",
+    "security": "Seguridad",
+    "about": "Acerca de",
+    "version": "Versión {{version}}",
+    "logout": "Cerrar sesión"
+  },
+  "security": {
+    "title": "Seguridad",
+    "biometrics": "Usar Biometría",
+    "pin": "Establecer PIN",
+    "backup": "Respaldar Billetera",
+    "backupWarning": "Guarda tu frase de recuperación en un lugar seguro. Cualquiera que la tenga puede acceder a tus fondos."
+  },
+  "errors": {
+    "networkError": "Error de red. Por favor verifica tu conexión.",
+    "timeout": "La solicitud tardó demasiado. Inténtalo de nuevo.",
+    "unknown": "Ocurrió un error inesperado."
+  }
+}

--- a/mobile/app/src/i18n/locales/fr.json
+++ b/mobile/app/src/i18n/locales/fr.json
@@ -1,0 +1,85 @@
+{
+  "common": {
+    "loading": "Chargement…",
+    "error": "Une erreur s'est produite",
+    "retry": "Réessayer",
+    "cancel": "Annuler",
+    "confirm": "Confirmer",
+    "close": "Fermer",
+    "back": "Retour",
+    "next": "Suivant",
+    "done": "Terminé",
+    "save": "Enregistrer",
+    "copy": "Copier",
+    "copied": "Copié !",
+    "share": "Partager"
+  },
+  "onboarding": {
+    "title": "Bienvenue sur Bridgelet",
+    "subtitle": "Envoyez et recevez des paiements Stellar partout, instantanément.",
+    "getStarted": "Commencer",
+    "alreadyHaveWallet": "J'ai déjà un portefeuille"
+  },
+  "claim": {
+    "title": "Réclamer un Paiement",
+    "subtitle": "Scannez ou entrez un code de réclamation Bridgelet pour recevoir des fonds.",
+    "inputLabel": "Code de Réclamation",
+    "inputPlaceholder": "Entrez ou collez votre code de réclamation",
+    "scanQr": "Scanner le QR Code",
+    "claimButton": "Réclamer les Fonds",
+    "claiming": "Réclamation en cours…",
+    "successTitle": "Paiement Réclamé !",
+    "successMessage": "{{amount}} {{asset}} a été ajouté à votre portefeuille.",
+    "errorInvalid": "Code de réclamation invalide ou expiré.",
+    "errorAlreadyClaimed": "Ce paiement a déjà été réclamé.",
+    "newWalletPrompt": "Pas encore de portefeuille ? Nous en créerons un pour vous.",
+    "existingWalletPrompt": "Réclamez sur votre portefeuille existant."
+  },
+  "send": {
+    "title": "Envoyer un Paiement",
+    "recipientLabel": "Destinataire",
+    "recipientPlaceholder": "Adresse Stellar ou ID Bridgelet",
+    "amountLabel": "Montant",
+    "amountPlaceholder": "0.00",
+    "assetLabel": "Actif",
+    "memoLabel": "Mémo (optionnel)",
+    "memoPlaceholder": "Ajouter une note",
+    "sendButton": "Envoyer",
+    "sending": "Envoi en cours…",
+    "successTitle": "Paiement Envoyé !",
+    "successMessage": "{{amount}} {{asset}} envoyé à {{recipient}}.",
+    "errorInsufficientFunds": "Fonds insuffisants.",
+    "errorInvalidAddress": "Adresse du destinataire invalide.",
+    "reviewTitle": "Vérifier le Paiement",
+    "fee": "Frais de réseau"
+  },
+  "wallet": {
+    "balance": "Solde",
+    "address": "Votre Adresse",
+    "noBalance": "Pas encore de solde",
+    "assets": "Actifs",
+    "history": "Historique des Transactions",
+    "noHistory": "Pas encore de transactions"
+  },
+  "settings": {
+    "title": "Paramètres",
+    "language": "Langue",
+    "theme": "Thème",
+    "security": "Sécurité",
+    "about": "À propos",
+    "version": "Version {{version}}",
+    "logout": "Déconnexion"
+  },
+  "security": {
+    "title": "Sécurité",
+    "biometrics": "Utiliser la Biométrie",
+    "pin": "Définir un PIN",
+    "backup": "Sauvegarder le Portefeuille",
+    "backupWarning": "Conservez votre phrase de récupération en lieu sûr. Quiconque la possède peut accéder à vos fonds."
+  },
+  "errors": {
+    "networkError": "Erreur réseau. Veuillez vérifier votre connexion.",
+    "timeout": "La requête a expiré. Veuillez réessayer.",
+    "unknown": "Une erreur inattendue s'est produite."
+  }
+}

--- a/mobile/e2e/claimFlow.test.ts
+++ b/mobile/e2e/claimFlow.test.ts
@@ -1,0 +1,135 @@
+/**
+ * e2e/claimFlow.test.ts
+ *
+ * Issue #485: Mobile E2E test suite with Detox
+ *
+ * Covers the claim flow for:
+ *  - New wallet path (no existing wallet)
+ *  - Existing wallet path
+ * Targets both iOS and Android simulators.
+ */
+
+import { device, element, by, expect, waitFor } from 'detox';
+
+const VALID_CLAIM_CODE = 'BL-TEST-CLAIM-001';
+const INVALID_CLAIM_CODE = 'BL-INVALID-CODE';
+const ALREADY_CLAIMED_CODE = 'BL-ALREADY-CLAIMED';
+
+describe('Claim Flow', () => {
+  beforeAll(async () => {
+    await device.launchApp({ newInstance: true });
+  });
+
+  afterEach(async () => {
+    await device.reloadReactNative();
+  });
+
+  // ── New wallet path ──────────────────────────────────────────────────────────
+
+  describe('New wallet path', () => {
+    it('should display the claim screen from onboarding', async () => {
+      // Arrive at onboarding
+      await expect(element(by.id('onboarding-title'))).toBeVisible();
+
+      // Tap "Get Started" which routes to claim
+      await element(by.id('onboarding-get-started')).tap();
+
+      // Claim screen should be visible
+      await expect(element(by.id('claim-screen'))).toBeVisible();
+    });
+
+    it('should show an error for an invalid claim code', async () => {
+      await element(by.id('onboarding-get-started')).tap();
+      await element(by.id('claim-code-input')).typeText(INVALID_CLAIM_CODE);
+      await element(by.id('claim-button')).tap();
+
+      await waitFor(element(by.id('claim-error-message')))
+        .toBeVisible()
+        .withTimeout(5000);
+
+      await expect(element(by.id('claim-error-message'))).toHaveText(
+        'Invalid or expired claim code.',
+      );
+    });
+
+    it('should create a wallet and claim funds with a valid code', async () => {
+      await element(by.id('onboarding-get-started')).tap();
+      await element(by.id('claim-code-input')).typeText(VALID_CLAIM_CODE);
+      await element(by.id('claim-button')).tap();
+
+      // Wallet creation prompt should appear for new users
+      await waitFor(element(by.id('new-wallet-prompt')))
+        .toBeVisible()
+        .withTimeout(5000);
+
+      await element(by.id('create-wallet-confirm')).tap();
+
+      // Success screen
+      await waitFor(element(by.id('claim-success-screen')))
+        .toBeVisible()
+        .withTimeout(10000);
+
+      await expect(element(by.id('claim-success-title'))).toBeVisible();
+    });
+
+    it('should show an error for an already-claimed code', async () => {
+      await element(by.id('onboarding-get-started')).tap();
+      await element(by.id('claim-code-input')).typeText(ALREADY_CLAIMED_CODE);
+      await element(by.id('claim-button')).tap();
+
+      await waitFor(element(by.id('claim-error-message')))
+        .toBeVisible()
+        .withTimeout(5000);
+
+      await expect(element(by.id('claim-error-message'))).toHaveText(
+        'This payment has already been claimed.',
+      );
+    });
+  });
+
+  // ── Existing wallet path ─────────────────────────────────────────────────────
+
+  describe('Existing wallet path', () => {
+    beforeEach(async () => {
+      // Navigate via the "I already have a wallet" path
+      await element(by.id('onboarding-existing-wallet')).tap();
+      // Assume wallet setup / import flow completes
+      await waitFor(element(by.id('home-screen')))
+        .toBeVisible()
+        .withTimeout(8000);
+    });
+
+    it('should reach the claim screen from the home tab', async () => {
+      await element(by.id('tab-claim')).tap();
+      await expect(element(by.id('claim-screen'))).toBeVisible();
+    });
+
+    it('should successfully claim funds to existing wallet', async () => {
+      await element(by.id('tab-claim')).tap();
+      await element(by.id('claim-code-input')).typeText(VALID_CLAIM_CODE);
+      await element(by.id('claim-button')).tap();
+
+      // Should NOT show new wallet prompt for existing wallet users
+      await expect(element(by.id('new-wallet-prompt'))).not.toBeVisible();
+
+      await waitFor(element(by.id('claim-success-screen')))
+        .toBeVisible()
+        .withTimeout(10000);
+
+      await expect(element(by.id('claim-success-title'))).toBeVisible();
+    });
+
+    it('should support scanning a QR code for the claim code', async () => {
+      await element(by.id('tab-claim')).tap();
+      await element(by.id('scan-qr-button')).tap();
+
+      await waitFor(element(by.id('qr-scanner-screen')))
+        .toBeVisible()
+        .withTimeout(5000);
+
+      // Simulator: close scanner (camera not available in CI)
+      await element(by.id('close-qr-scanner')).tap();
+      await expect(element(by.id('claim-screen'))).toBeVisible();
+    });
+  });
+});

--- a/mobile/e2e/jest.config.js
+++ b/mobile/e2e/jest.config.js
@@ -1,0 +1,15 @@
+/** @type {import('@jest/types').Config.InitialOptions} */
+module.exports = {
+  rootDir: '..',
+  testMatch: ['<rootDir>/e2e/**/*.test.ts'],
+  testTimeout: 120000,
+  maxWorkers: 1,
+  globalSetup: 'detox/runners/jest/globalSetup',
+  globalTeardown: 'detox/runners/jest/globalTeardown',
+  reporters: ['detox/runners/jest/reporter'],
+  testEnvironment: 'detox/runners/jest/testEnvironment',
+  verbose: true,
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: { jsx: 'react-native' } }],
+  },
+};

--- a/mobile/e2e/sendFlow.test.ts
+++ b/mobile/e2e/sendFlow.test.ts
@@ -1,0 +1,126 @@
+/**
+ * e2e/sendFlow.test.ts
+ *
+ * Issue #485: Mobile E2E test suite with Detox — Send flow happy path
+ *
+ * Covers the send flow happy path on both iOS and Android simulators.
+ */
+
+import { device, element, by, expect, waitFor } from 'detox';
+
+const VALID_STELLAR_ADDRESS =
+  'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN';
+const SEND_AMOUNT = '10';
+const SEND_ASSET = 'USDC';
+
+describe('Send Flow', () => {
+  beforeAll(async () => {
+    await device.launchApp({ newInstance: true });
+
+    // Navigate past onboarding to an existing-wallet session
+    await element(by.id('onboarding-existing-wallet')).tap();
+    await waitFor(element(by.id('home-screen')))
+      .toBeVisible()
+      .withTimeout(8000);
+  });
+
+  afterEach(async () => {
+    // Return to home after each test
+    await device.reloadReactNative();
+    await element(by.id('onboarding-existing-wallet')).tap();
+    await waitFor(element(by.id('home-screen')))
+      .toBeVisible()
+      .withTimeout(8000);
+  });
+
+  it('should navigate to the send screen from the home tab', async () => {
+    await element(by.id('tab-send')).tap();
+    await expect(element(by.id('send-screen'))).toBeVisible();
+  });
+
+  it('should show validation error for empty recipient', async () => {
+    await element(by.id('tab-send')).tap();
+    await element(by.id('send-amount-input')).typeText(SEND_AMOUNT);
+    await element(by.id('send-button')).tap();
+
+    await expect(element(by.id('send-recipient-error'))).toBeVisible();
+  });
+
+  it('should show validation error for invalid recipient address', async () => {
+    await element(by.id('tab-send')).tap();
+    await element(by.id('send-recipient-input')).typeText('not-a-valid-address');
+    await element(by.id('send-amount-input')).typeText(SEND_AMOUNT);
+    await element(by.id('send-button')).tap();
+
+    await waitFor(element(by.id('send-error-message')))
+      .toBeVisible()
+      .withTimeout(4000);
+
+    await expect(element(by.id('send-error-message'))).toHaveText(
+      'Invalid recipient address.',
+    );
+  });
+
+  it('should complete the send happy path', async () => {
+    await element(by.id('tab-send')).tap();
+
+    // Fill recipient
+    await element(by.id('send-recipient-input')).typeText(VALID_STELLAR_ADDRESS);
+
+    // Fill amount
+    await element(by.id('send-amount-input')).typeText(SEND_AMOUNT);
+
+    // Select asset
+    await element(by.id('send-asset-picker')).tap();
+    await element(by.id(`asset-option-${SEND_ASSET}`)).tap();
+
+    // Tap send
+    await element(by.id('send-button')).tap();
+
+    // Review screen
+    await waitFor(element(by.id('send-review-screen')))
+      .toBeVisible()
+      .withTimeout(5000);
+
+    await expect(element(by.id('review-amount'))).toBeVisible();
+    await expect(element(by.id('review-recipient'))).toBeVisible();
+    await expect(element(by.id('review-fee'))).toBeVisible();
+
+    // Confirm
+    await element(by.id('confirm-send-button')).tap();
+
+    // Success
+    await waitFor(element(by.id('send-success-screen')))
+      .toBeVisible()
+      .withTimeout(15000);
+
+    await expect(element(by.id('send-success-title'))).toBeVisible();
+  });
+
+  it('should allow adding an optional memo', async () => {
+    await element(by.id('tab-send')).tap();
+    await element(by.id('send-recipient-input')).typeText(VALID_STELLAR_ADDRESS);
+    await element(by.id('send-amount-input')).typeText(SEND_AMOUNT);
+    await element(by.id('send-memo-input')).typeText('Payment for services');
+    await element(by.id('send-button')).tap();
+
+    await waitFor(element(by.id('send-review-screen')))
+      .toBeVisible()
+      .withTimeout(5000);
+
+    await expect(element(by.id('review-memo'))).toHaveText('Payment for services');
+  });
+
+  it('should support scanning a recipient QR code', async () => {
+    await element(by.id('tab-send')).tap();
+    await element(by.id('scan-recipient-qr')).tap();
+
+    await waitFor(element(by.id('qr-scanner-screen')))
+      .toBeVisible()
+      .withTimeout(5000);
+
+    // Simulator: close scanner
+    await element(by.id('close-qr-scanner')).tap();
+    await expect(element(by.id('send-screen'))).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Resolves all four mobile issues assigned to @BigBen-7 in a single PR.

Closes #484
Closes #485
Closes #486
Closes #487

---

## #484 — Mobile app localization

### Files
- `mobile/app/src/i18n/locales/en.json` *(new)* — English base strings
- `mobile/app/src/i18n/locales/es.json` *(new)* — Full Spanish translation
- `mobile/app/src/i18n/locales/fr.json` *(new)* — Full French translation
- `mobile/app/src/i18n/index.ts` *(new)* — i18n setup module

All screens covered: onboarding, claim, send, wallet, settings, security, error states. String keys use dot-notation (`claim.successMessage`) with interpolation support (`{{amount}}`, `{{asset}}`).

The `initI18n()` function detects device locale via `expo-localization`, falls back to English, and persists manual overrides in AsyncStorage. `changeLanguage('es')` switches at runtime and survives app restarts.

---

## #485 — Mobile E2E test suite with Detox

### Files
- `mobile/e2e/claimFlow.test.ts` *(new)*
- `mobile/e2e/sendFlow.test.ts` *(new)*
- `mobile/e2e/jest.config.js` *(new)*
- `mobile/.detoxrc.js` *(new)*

**Claim flow coverage:**
- New wallet path: onboarding → claim → wallet creation prompt → success
- Existing wallet path: home tab → claim → success (no wallet prompt)
- Invalid code error, already-claimed error, QR scanner open/close

**Send flow coverage (happy path):**
- Recipient + amount + asset selection → review screen → confirm → success
- Empty recipient / invalid address validation errors
- Optional memo field
- QR scanner for recipient address

Both `ios.sim.debug` (iPhone 15) and `android.emu.debug` (Pixel 7 API 34) configurations defined in `.detoxrc.js`.

---

## #486 — Mobile CI build and test pipeline

### Files
- `.github/workflows/mobile-ci.yml` *(new)*

Triggers on any PR/push touching `mobile/`. Jobs:

| Job | Runner | What it does |
|-----|--------|-------------|
| `lint` | ubuntu-latest | ESLint + `tsc --noEmit` |
| `unit-tests` | ubuntu-latest | Jest with coverage upload |
| `build-android` | ubuntu-latest | Gradle debug APK + test APK |
| `build-ios` | macos-14 | xcodebuild debug sim build |
| `e2e-android` | ubuntu-latest | Detox E2E on Pixel 7 emulator |
| `e2e-ios` | macos-14 | Detox E2E on iPhone 15 simulator |

Includes Gradle and DerivedData caching for fast incremental builds. Artifacts (APK, .app, coverage, Detox screenshots) retained for 7 days.

---

## #487 — App store release checklist and metadata

### Files
- `mobile/APP_STORE_RELEASE.md` *(new)*

Covers:
- Pre-release checklist (code, security, accessibility)
- Apple App Store: metadata table, build requirements, age rating, usage descriptions
- Google Play: metadata table, target SDK, permissions
- **Privacy labels** — accurately drafted against what Bridgelet actually collects (pseudonymous public key, opt-in crash logs, no financial data stored by app)
- Screenshot size specs for all required iOS and Android device classes
- Ready-to-paste app name, subtitle, category, short and full descriptions
- Release notes template