### PR TITLE
Frontend/Mobile: asset optimization, bundle budget CI, reduced-motion, mobile ADR (#472 #473 #474 #475)

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -1,0 +1,133 @@
+name: Bundle Size Budget
+
+# Issue #473: Bundle size budget enforcement
+# Runs on PRs touching frontend/, measures per-route first-load JS against
+# defined budgets, and fails CI + posts a PR comment on regressions.
+
+on:
+  pull_request:
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/bundle-size.yml'
+
+concurrency:
+  group: bundle-size-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bundle-size:
+    name: Bundle Size Check
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+        env:
+          NODE_ENV: production
+
+      - name: Check bundle budgets
+        id: budget
+        run: |
+          # Run budget check and capture output + exit code
+          set +e
+          OUTPUT=$(npx tsx scripts/bundle-budget-check.ts --json 2>&1)
+          EXIT_CODE=$?
+          set -e
+          echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
+          echo "$OUTPUT" > /tmp/budget-results.json
+          # Also run human-readable version for the logs
+          npx tsx scripts/bundle-budget-check.ts || true
+
+      - name: Post PR comment with budget results
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let results;
+            try {
+              results = JSON.parse(fs.readFileSync('/tmp/budget-results.json', 'utf8'));
+            } catch {
+              console.log('Could not parse budget results JSON');
+              return;
+            }
+
+            const passed = results.every(r => r.passed);
+            const formatKB = (bytes) => `${(bytes / 1024).toFixed(1)} kB`;
+
+            const rows = results
+              .sort((a, b) => b.sizeBytes - a.sizeBytes)
+              .map(r => {
+                const status = r.passed ? '✅' : `❌ (+${formatKB(r.overageBytes)})`;
+                return `| \`${r.route}\` | ${formatKB(r.sizeBytes)} | ${formatKB(r.budgetBytes)} | ${status} |`;
+              })
+              .join('\n');
+
+            const header = passed
+              ? '## ✅ Bundle Size: All routes within budget'
+              : '## ❌ Bundle Size: Budget exceeded — please reduce first-load JS';
+
+            const body = `${header}
+
+            | Route | Size | Budget | Status |
+            |-------|------|--------|--------|
+            ${rows}
+
+            <details>
+            <summary>How to fix over-budget routes</summary>
+
+            - **Code-split** heavy dependencies with \`dynamic(() => import(...))\`
+            - **Move Stellar SDK** usage server-side (API routes / Server Components)
+            - **Tree-shake** — check if you're importing entire libraries for a few utils
+            - **Defer** non-critical scripts and analytics until after hydration
+            </details>
+
+            _Budgets: \`/send\` and \`/claim/[token]\` → 200 kB · \`/\` → 250 kB · other routes → 300 kB_`;
+
+            // Find and update existing comment or create new one
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c =>
+              c.user?.login === 'github-actions[bot]' &&
+              c.body?.includes('Bundle Size')
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: Fail if over budget
+        if: steps.budget.outputs.exit_code != '0'
+        run: |
+          echo "Bundle size budget exceeded. See PR comment for details."
+          exit 1

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -7,3 +7,22 @@
 body {
   @apply min-h-screen bg-slate-50 text-slate-900 antialiased;
 }
+
+/* Issue #474: Step-in animation for HowItWorks component.
+   Respects prefers-reduced-motion at the CSS level as a second
+   layer of protection alongside the useReducedMotion React hook. */
+@keyframes step-in {
+  from { opacity: 0; transform: translateY(16px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.animate-step-in {
+  animation: step-in 0.4s ease-out both;
+  animation-delay: var(--step-delay, 0ms);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-step-in {
+    animation: none;
+  }
+}

--- a/frontend/components/HowItWorks.tsx
+++ b/frontend/components/HowItWorks.tsx
@@ -1,0 +1,117 @@
+/**
+ * HowItWorks.tsx
+ *
+ * Issue #474: Reduced-motion preference support for homepage animation.
+ *
+ * The "How It Works" explainer section with step-by-step animation.
+ *
+ * Behaviour:
+ *  - Default (motion OK): steps fade and slide in sequentially with a
+ *    staggered CSS animation as they enter the viewport.
+ *  - Reduced-motion: all steps visible immediately, no animation or
+ *    transition. Content is fully understandable without motion cues.
+ *
+ * The reduced-motion state is driven by the OS `prefers-reduced-motion`
+ * media query via the `useReducedMotion` hook, not a manual toggle.
+ */
+'use client';
+
+import { useReducedMotion } from '@/lib/useReducedMotion';
+
+interface Step {
+  number: number;
+  title: string;
+  description: string;
+  icon: string;
+}
+
+const STEPS: Step[] = [
+  {
+    number: 1,
+    icon: '💸',
+    title: 'Sender creates a payment link',
+    description:
+      'Enter the amount and asset. Bridgelet generates a unique, one-time claim link — no recipient wallet address needed upfront.',
+  },
+  {
+    number: 2,
+    icon: '📲',
+    title: 'Share by any means',
+    description:
+      'Send the link via SMS, WhatsApp, email, or show a QR code in person. The recipient taps or scans to claim.',
+  },
+  {
+    number: 3,
+    icon: '✅',
+    title: 'Recipient claims instantly',
+    description:
+      'Funds arrive in seconds on the Stellar network. New users are guided to create a wallet — no prior crypto knowledge required.',
+  },
+];
+
+export function HowItWorks() {
+  const prefersReducedMotion = useReducedMotion();
+
+  return (
+    <section
+      aria-labelledby="how-it-works-heading"
+      className="py-16 px-4 sm:px-6 lg:px-8"
+    >
+      <h2
+        id="how-it-works-heading"
+        className="text-2xl font-bold text-center text-slate-900 mb-12"
+      >
+        How It Works
+      </h2>
+
+      <ol
+        className="mx-auto max-w-3xl space-y-8"
+        // Suppress list semantics announcement — numbered visually
+        aria-label="Three steps to send and claim a payment"
+      >
+        {STEPS.map((step, index) => (
+          <li
+            key={step.number}
+            className={[
+              'flex gap-5 rounded-xl border border-slate-200 bg-white p-6 shadow-sm',
+              // Animated variant: staggered fade-slide-in using CSS custom property
+              !prefersReducedMotion && 'animate-step-in',
+            ]
+              .filter(Boolean)
+              .join(' ')}
+            style={
+              !prefersReducedMotion
+                ? ({ '--step-delay': `${index * 150}ms` } as React.CSSProperties)
+                : undefined
+            }
+          >
+            {/* Step number badge */}
+            <div
+              aria-hidden="true"
+              className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-slate-900 text-sm font-bold text-white"
+            >
+              {step.number}
+            </div>
+
+            <div className="flex-1">
+              <div className="flex items-center gap-2 mb-1">
+                <span aria-hidden="true" className="text-xl">{step.icon}</span>
+                <h3 className="font-semibold text-slate-900">{step.title}</h3>
+              </div>
+              <p className="text-sm text-slate-600 leading-relaxed">
+                {step.description}
+              </p>
+            </div>
+          </li>
+        ))}
+      </ol>
+
+      {/* Reduced-motion note — visible only when preference is active */}
+      {prefersReducedMotion && (
+        <p className="sr-only" aria-live="polite">
+          Animations are disabled because you have reduced motion enabled in your system settings.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/frontend/components/OptimizedImage.tsx
+++ b/frontend/components/OptimizedImage.tsx
@@ -1,0 +1,54 @@
+/**
+ * OptimizedImage.tsx
+ *
+ * Issue #472: Image and static asset optimization.
+ *
+ * A thin wrapper around next/image that enforces the project's image
+ * optimization conventions:
+ *  - Above-the-fold images: priority={true}, no lazy loading
+ *  - Below-the-fold images: loading="lazy" (default for next/image)
+ *  - All images get sizes attribute for responsive layout hints
+ *  - Alt text required — TypeScript enforces it
+ *
+ * Usage:
+ *   // Above the fold (hero, first visible image)
+ *   <OptimizedImage src="/hero.webp" alt="..." width={800} height={600} priority />
+ *
+ *   // Below the fold (feature images, screenshots)
+ *   <OptimizedImage src="/feature.webp" alt="..." width={400} height={300} />
+ */
+
+import Image, { type ImageProps } from 'next/image';
+
+interface OptimizedImageProps extends Omit<ImageProps, 'alt'> {
+  /** Alt text is required for accessibility. Use "" for decorative images. */
+  alt: string;
+  /**
+   * Set true for above-the-fold images (hero, first viewport).
+   * Disables lazy loading and preloads the image as high priority.
+   */
+  priority?: boolean;
+  /**
+   * Responsive sizes hint. Defaults to a sensible full-width value.
+   * Override for images that don't span the full viewport width.
+   */
+  sizes?: string;
+}
+
+export function OptimizedImage({
+  alt,
+  priority = false,
+  sizes = '(max-width: 640px) 100vw, (max-width: 1024px) 80vw, 60vw',
+  ...props
+}: OptimizedImageProps) {
+  return (
+    <Image
+      alt={alt}
+      priority={priority}
+      // next/image defaults to lazy loading — explicitly set for below-fold
+      loading={priority ? 'eager' : 'lazy'}
+      sizes={sizes}
+      {...props}
+    />
+  );
+}

--- a/frontend/lib/useReducedMotion.ts
+++ b/frontend/lib/useReducedMotion.ts
@@ -1,0 +1,40 @@
+/**
+ * useReducedMotion.ts
+ *
+ * Issue #474: Reduced-motion preference support for homepage animation.
+ *
+ * Reads the OS-level `prefers-reduced-motion` media query and returns a
+ * boolean. Components should disable or significantly reduce animations
+ * when this returns true.
+ *
+ * Usage:
+ *   const prefersReducedMotion = useReducedMotion();
+ *
+ *   <div className={prefersReducedMotion ? 'static-steps' : 'animated-steps'}>
+ *     ...
+ *   </div>
+ */
+'use client';
+
+import { useEffect, useState } from 'react';
+
+const QUERY = '(prefers-reduced-motion: reduce)';
+
+export function useReducedMotion(): boolean {
+  const [prefersReduced, setPrefersReduced] = useState<boolean>(() => {
+    // Safe default for SSR — no window available
+    if (typeof window === 'undefined') return false;
+    return window.matchMedia(QUERY).matches;
+  });
+
+  useEffect(() => {
+    const mq = window.matchMedia(QUERY);
+    setPrefersReduced(mq.matches);
+
+    const handler = (e: MediaQueryListEvent) => setPrefersReduced(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+
+  return prefersReduced;
+}

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,6 +1,53 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+
+  /**
+   * Issue #472: Image and static asset optimization.
+   *
+   * - Enables WebP/AVIF format negotiation automatically (next/image default).
+   * - Sets device sizes matching common mobile breakpoints used in remittance
+   *   target markets (low-end Android devices dominate).
+   * - Keeps a minimal cache TTL for frequently-updated assets while maximising
+   *   CDN reuse for stable ones (1 year).
+   */
+  images: {
+    formats: ['image/avif', 'image/webp'],
+    deviceSizes: [360, 414, 640, 750, 828, 1080, 1200, 1920],
+    imageSizes: [16, 32, 48, 64, 96, 128, 256],
+    minimumCacheTTL: 31536000, // 1 year for versioned assets
+    // Allow images from the Bridgelet CDN
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'assets.bridgelet.org',
+      },
+    ],
+  },
+
+  /**
+   * Issue #473: Bundle size budget enforcement.
+   *
+   * Webpack performance hints are set to 'error' in production so that
+   * the Next.js build fails (non-zero exit) when a chunk exceeds budget.
+   * This is the CI gate — the budget-check.ts script provides the per-route
+   * report and PR comment.
+   *
+   * Budgets (gzip-compressed targets — these raw values are ~2.5× larger):
+   *   /send, /claim/[token] — 200 kB max first-load JS (critical user paths)
+   *   all other routes      — 300 kB max
+   *   single assets         — 100 kB max
+   */
+  webpack(config, { isServer }) {
+    if (!isServer) {
+      config.performance = {
+        hints: process.env.NODE_ENV === 'production' ? 'error' : 'warning',
+        maxEntrypointSize: 300 * 1024,  // 300 kB
+        maxAssetSize: 100 * 1024,       // 100 kB per asset
+      };
+    }
+    return config;
+  },
 };
 
 module.exports = nextConfig;

--- a/frontend/scripts/bundle-budget-check.ts
+++ b/frontend/scripts/bundle-budget-check.ts
@@ -1,0 +1,194 @@
+#!/usr/bin/env tsx
+/**
+ * scripts/bundle-budget-check.ts
+ *
+ * Issue #473: Bundle size budget enforcement.
+ *
+ * Reads the Next.js build manifest (.next/build-manifest.json and
+ * .next/app-build-manifest.json) and measures the first-load JS per route
+ * against defined budgets. Exits non-zero on violations so CI fails the build.
+ *
+ * Budgets (gzip-compressed estimate — actual JS is ~2.5× raw):
+ *   /send                — 200 kB  (critical payment path)
+ *   /claim/[token]       — 200 kB  (critical claim path)
+ *   /                    — 250 kB
+ *   all other routes     — 300 kB
+ *
+ * Usage:
+ *   npx tsx scripts/bundle-budget-check.ts
+ *   npx tsx scripts/bundle-budget-check.ts --json   (outputs JSON for CI comments)
+ */
+
+import { existsSync, readFileSync, statSync } from 'fs';
+import { resolve, join } from 'path';
+
+const ROOT = resolve(__dirname, '..');
+const NEXT_DIR = join(ROOT, '.next');
+const ARGS = process.argv.slice(2);
+const JSON_OUTPUT = ARGS.includes('--json');
+
+// ─── Budget definitions ───────────────────────────────────────────────────────
+// Values in bytes (uncompressed). Gzip is typically ~40% of raw size.
+// We set budgets at ~2.5× the gzip target.
+
+const ROUTE_BUDGETS: Record<string, number> = {
+  '/send':           200 * 1024,   // 200 kB — critical path
+  '/claim/[token]':  200 * 1024,   // 200 kB — critical path
+  '/':               250 * 1024,   // 250 kB — homepage
+  '__DEFAULT__':     300 * 1024,   // 300 kB — all other routes
+};
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface BudgetResult {
+  route: string;
+  sizeBytes: number;
+  budgetBytes: number;
+  passed: boolean;
+  overageBytes: number;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function formatBytes(bytes: number): string {
+  return `${(bytes / 1024).toFixed(1)} kB`;
+}
+
+function fileSize(path: string): number {
+  try {
+    return statSync(path).size;
+  } catch {
+    return 0;
+  }
+}
+
+function readJson<T>(path: string): T | null {
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8')) as T;
+  } catch {
+    return null;
+  }
+}
+
+// ─── Build manifest parsing ───────────────────────────────────────────────────
+
+interface BuildManifest {
+  pages?: Record<string, string[]>;
+}
+
+interface AppBuildManifest {
+  pages?: Record<string, string[]>;
+}
+
+function collectRouteChunks(): Map<string, string[]> {
+  const result = new Map<string, string[]>();
+
+  // Pages router
+  const buildManifest = readJson<BuildManifest>(join(NEXT_DIR, 'build-manifest.json'));
+  if (buildManifest?.pages) {
+    for (const [route, chunks] of Object.entries(buildManifest.pages)) {
+      result.set(route, chunks);
+    }
+  }
+
+  // App router
+  const appManifest = readJson<AppBuildManifest>(join(NEXT_DIR, 'app-build-manifest.json'));
+  if (appManifest?.pages) {
+    for (const [route, chunks] of Object.entries(appManifest.pages)) {
+      // Normalise app router routes: strip trailing /page
+      const normalized = route.replace(/\/page$/, '') || '/';
+      const existing = result.get(normalized) ?? [];
+      result.set(normalized, [...new Set([...existing, ...chunks])]);
+    }
+  }
+
+  return result;
+}
+
+function measureRoute(chunks: string[]): number {
+  return chunks.reduce((total, chunk) => {
+    const path = join(NEXT_DIR, chunk.startsWith('/') ? chunk.slice(1) : chunk);
+    return total + fileSize(path);
+  }, 0);
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+function getBudget(route: string): number {
+  return ROUTE_BUDGETS[route] ?? ROUTE_BUDGETS['__DEFAULT__']!;
+}
+
+function main(): void {
+  if (!existsSync(NEXT_DIR)) {
+    console.error('❌  .next/ directory not found. Run `next build` first.');
+    process.exit(1);
+  }
+
+  const routeChunks = collectRouteChunks();
+  if (routeChunks.size === 0) {
+    console.error('❌  No routes found in build manifest. Was the build successful?');
+    process.exit(1);
+  }
+
+  const results: BudgetResult[] = [];
+
+  for (const [route, chunks] of routeChunks) {
+    const sizeBytes = measureRoute(chunks);
+    const budgetBytes = getBudget(route);
+    const passed = sizeBytes <= budgetBytes;
+    results.push({
+      route,
+      sizeBytes,
+      budgetBytes,
+      passed,
+      overageBytes: Math.max(0, sizeBytes - budgetBytes),
+    });
+  }
+
+  if (JSON_OUTPUT) {
+    console.log(JSON.stringify(results, null, 2));
+    const anyFailed = results.some((r) => !r.passed);
+    process.exit(anyFailed ? 1 : 0);
+    return;
+  }
+
+  // ── Human-readable table ──────────────────────────────────────────────────
+
+  console.log('\n📦  Bundle Size Budget Report\n');
+  console.log(
+    '  Route'.padEnd(35) +
+    'Size'.padStart(10) +
+    'Budget'.padStart(10) +
+    'Status'.padStart(10),
+  );
+  console.log('  ' + '─'.repeat(63));
+
+  let anyFailed = false;
+  for (const r of results.sort((a, b) => b.sizeBytes - a.sizeBytes)) {
+    const status = r.passed ? '✅ OK' : `❌ +${formatBytes(r.overageBytes)}`;
+    if (!r.passed) anyFailed = true;
+    console.log(
+      `  ${r.route.padEnd(33)}` +
+      formatBytes(r.sizeBytes).padStart(10) +
+      formatBytes(r.budgetBytes).padStart(10) +
+      status.padStart(14),
+    );
+  }
+
+  console.log('');
+
+  if (anyFailed) {
+    console.error(
+      '❌  Bundle budget exceeded on one or more routes.\n' +
+      '    Review the output above and reduce first-load JS.\n' +
+      '    Tips: code-split heavy dependencies, defer non-critical imports,\n' +
+      '    move Stellar SDK usage server-side where possible.\n',
+    );
+    process.exit(1);
+  } else {
+    console.log('✅  All routes are within budget.\n');
+    process.exit(0);
+  }
+}
+
+main();

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,136 @@
+# Bridgelet Mobile
+
+React Native + Expo mobile app for Bridgelet payment flows.
+
+> **Stack decision:** See [`docs/ADR-001-scaffold.md`](./docs/ADR-001-scaffold.md)
+
+---
+
+## Prerequisites
+
+| Tool | Version | Install |
+|------|---------|---------|
+| Node.js | ≥ 20 | [nodejs.org](https://nodejs.org) |
+| npm | ≥ 10 | bundled with Node |
+| Expo CLI | latest | `npm install -g expo-cli` |
+| iOS Simulator | Xcode 15+ | Mac only — App Store |
+| Android Emulator | Android Studio | [developer.android.com](https://developer.android.com/studio) |
+
+---
+
+## Quick Start
+
+```bash
+# 1. Install dependencies
+cd mobile
+npm install
+
+# 2. Start Expo dev server
+npx expo start
+
+# 3. Open on a device / simulator
+#    Press i  — iOS Simulator
+#    Press a  — Android Emulator
+#    Scan QR  — physical device via Expo Go
+```
+
+---
+
+## Environment Variables
+
+Copy `.env.example` to `.env.local` and fill in the values:
+
+```bash
+cp .env.example .env.local
+```
+
+| Variable | Description |
+|----------|-------------|
+| `EXPO_PUBLIC_API_URL` | Bridgelet API base URL (e.g. `https://api.bridgelet.org`) |
+| `EXPO_PUBLIC_PROJECT_ID` | Expo project ID for push notifications |
+
+---
+
+## Project Structure
+
+```
+mobile/
+├── app/                    # Expo Router screens (file-based routing)
+│   ├── _layout.tsx         # Root layout — providers, fonts, deep link setup
+│   ├── index.tsx           # Entry / splash redirect
+│   ├── (tabs)/             # Tab bar screens
+│   ├── claim/              # Claim flow screens
+│   ├── send/               # Send flow screens
+│   └── security/           # Biometric / PIN setup
+├── app/src/                # Feature logic
+│   ├── components/         # Shared UI components
+│   ├── hooks/              # Custom hooks (wallet, network, biometric, etc.)
+│   ├── i18n/               # Localisation (en, es, fr)
+│   ├── notifications/      # Push notification setup
+│   └── ...
+├── e2e/                    # Detox E2E tests
+├── docs/                   # Architecture decision records
+└── .detoxrc.js             # Detox configuration
+```
+
+---
+
+## Running Tests
+
+```bash
+# Unit tests
+npm test
+
+# Unit tests with coverage
+npm test -- --coverage
+
+# Detox E2E — iOS Simulator
+npx detox build --configuration ios.sim.debug
+npx detox test --configuration ios.sim.debug
+
+# Detox E2E — Android Emulator
+npx detox build --configuration android.emu.debug
+npx detox test --configuration android.emu.debug
+```
+
+---
+
+## Building for Distribution
+
+Bridgelet uses **EAS Build** for CI/CD artefacts.
+
+```bash
+# Install EAS CLI
+npm install -g eas-cli
+
+# iOS debug build
+eas build --platform ios --profile development
+
+# Android debug build
+eas build --platform android --profile development
+
+# Production build (requires app store credentials)
+eas build --platform all --profile production
+```
+
+See [`../mobile/APP_STORE_RELEASE.md`](./APP_STORE_RELEASE.md) for release checklist.
+
+---
+
+## Deep Links
+
+Bridgelet handles two URL formats:
+
+| Format | Example |
+|--------|---------|
+| Universal Link | `https://bridgelet.org/claim/<token>` |
+| Custom scheme | `bridgelet://claim/<token>` |
+
+Test deep links on simulator:
+```bash
+# iOS
+xcrun simctl openurl booted "bridgelet://claim/BL-TEST-001"
+
+# Android
+adb shell am start -W -a android.intent.action.VIEW -d "bridgelet://claim/BL-TEST-001"
+```

--- a/mobile/docs/ADR-001-scaffold.md
+++ b/mobile/docs/ADR-001-scaffold.md
@@ -1,0 +1,54 @@
+# ADR-001: Mobile App Technical Scaffold
+
+**Date:** 2026-08-26
+**Status:** Accepted
+**Issue:** #475
+
+---
+
+## Context
+
+The `mobile/` directory exists in the repository but no formal decision record
+existed for the chosen technology stack. Several mobile issues (#476–#487) were
+being scoped against an unconfirmed scaffold, creating ambiguity.
+
+Three approaches were evaluated:
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| **React Native + Expo** | TypeScript/React shared with `frontend/`; large Stellar ecosystem support; fastest iteration with Expo Go | JS bridge overhead on complex animations |
+| Flutter | Excellent native performance; strong cross-platform UI | Dart — no code-sharing with `frontend/`; limited Stellar wallet deep-link ecosystem |
+| Native (Swift/Kotlin) | Maximum platform performance | Two separate codebases; doubles maintenance burden |
+
+## Decision
+
+**React Native with Expo (SDK 52+)** using the **Expo Router** file-based
+navigation (App Router model, same mental model as `frontend/`).
+
+## Rationale
+
+1. **Code-sharing with `frontend/`**: TypeScript, React hooks, Zod schemas, and
+   utility functions in `frontend/lib/` can be shared directly or with minimal
+   adaptation. The team already knows React.
+
+2. **Stellar wallet ecosystem**: LOBSTR (the dominant mobile Stellar wallet)
+   provides SEP-7 deep link support that works cleanly with `Linking` in React
+   Native. Freighter's mobile support is also React Native-first.
+
+3. **Expo managed workflow** removes native build toolchain complexity from
+   developer machines. EAS Build handles iOS/Android CI artefacts without
+   requiring macOS for Android builds.
+
+4. **Expo Router** mirrors the Next.js App Router file convention used in
+   `frontend/app/`, reducing context-switch cost for contributors working
+   across both surfaces.
+
+## Consequences
+
+- All mobile code lives in `mobile/` and uses TypeScript + React Native.
+- Shared logic (validation, API types) should be extracted to a future
+  `packages/shared/` workspace package rather than copied.
+- Native modules requiring bare workflow (e.g. custom camera processing)
+  can be added via Expo Config Plugins without ejecting.
+- Flutter or native rewrites would require a new ADR and significant
+  migration effort.


### PR DESCRIPTION
## Summary

Resolves four issues assigned to @monique-7arch in a single PR.

Closes #472
Closes #473
Closes #474
Closes #475

---

## #472 — Image and static asset optimization

**Files:** `frontend/next.config.js`, `frontend/components/OptimizedImage.tsx`

- `next.config.js` updated with AVIF/WebP format negotiation, mobile-first `deviceSizes` (360px–1920px), 1-year cache TTL, and webpack performance hints set to `'error'` in production.
- `OptimizedImage` wrapper enforces `next/image` usage across the project:
  - `priority` prop for above-the-fold images — disables lazy loading and triggers preload.
  - Below-the-fold images default to `loading="lazy"`.
  - `alt` is required at the TypeScript level — no silent omissions.
  - Default `sizes` attribute for responsive layout hints.

---

## #473 — Bundle size budget enforcement

**Files:** `frontend/scripts/bundle-budget-check.ts`, `.github/workflows/bundle-size.yml`

- `bundle-budget-check.ts` reads the Next.js build manifest, measures first-load JS per route, and enforces budgets:
  - `/send` and `/claim/[token]` → **200 kB** (critical user paths)
  - `/` → **250 kB**
  - All other routes → **300 kB**
  - `--json` flag for CI machine consumption.
- `bundle-size.yml` workflow triggers on PRs touching `frontend/`, builds, runs the check, posts/updates a PR comment with a formatted route table and fix guidance, then fails CI on any breach.

---

## #474 — Reduced-motion preference support

**Files:** `frontend/lib/useReducedMotion.ts`, `frontend/components/HowItWorks.tsx`, `frontend/app/globals.css`

- `useReducedMotion` hook reads `prefers-reduced-motion` via `matchMedia`, SSR-safe, live-updates on OS change.
- `HowItWorks` component:
  - **Default:** staggered CSS `step-in` animation with `--step-delay` custom property.
  - **Reduced motion:** all steps rendered fully visible immediately — content is **fully understandable** without any animation cues, not just visually simplified.
  - `sr-only` live region announces the reduced-motion state to screen readers.
- `globals.css`: `@keyframes step-in` + `.animate-step-in` + `@media (prefers-reduced-motion: reduce)` block as a CSS-level second line of defence.

---

## #475 — Mobile app technical scaffold decision record

**Files:** `mobile/docs/ADR-001-scaffold.md`, `mobile/README.md`

- **ADR-001** documents the decision to use **React Native + Expo (SDK 52+) with Expo Router**, with rationale:
  - TypeScript/React code-sharing with `frontend/`
  - LOBSTR/SEP-7 deep link ecosystem support for Stellar wallets
  - Expo managed workflow removes native toolchain burden
  - Expo Router mirrors the Next.js App Router convention
  - Evaluated alternatives: Flutter (no code-sharing, limited Stellar ecosystem), Native (double maintenance burden)
- **`mobile/README.md`:** prerequisites, quick start, env vars, project structure, unit + Detox E2E commands, EAS Build instructions, and deep link testing commands.
