### PR TITLE
feat: wallet connect persistence, expiry summary, fee estimation, batch send

### DIFF
--- a/frontend/app/send/page.tsx
+++ b/frontend/app/send/page.tsx
@@ -1,5 +1,5 @@
 import { PageShell } from '@/components/page-shell';
-import { SendForm } from '@/components/send-form';
+import { SendPageClient } from '@/components/send-page-client';
 
 export default function SendPage() {
   return (
@@ -7,7 +7,7 @@ export default function SendPage() {
       title="Create a new ephemeral account"
       description="Ephemeral accounts are temporary accounts that can be used to send and receive crypto. They are a great way to try out the network without having to create a full account."
     >
-      <SendForm />
+      <SendPageClient />
     </PageShell>
   );
 }

--- a/frontend/components/batch-send-form.test.tsx
+++ b/frontend/components/batch-send-form.test.tsx
@@ -65,25 +65,25 @@ describe('parseCsv', () => {
   it('parses a CSV without a header row', () => {
     const rows = parseCsv('Alice,alice@example.com,10,XLM\nBob,bob@example.com,5,USDC');
     expect(rows).toHaveLength(2);
-    expect(rows[0].name).toBe('Alice');
-    expect(rows[1].assetCode).toBe('USDC');
+    expect(rows[0]!.name).toBe('Alice');
+    expect(rows[1]!.assetCode).toBe('USDC');
   });
 
   it('skips a header row starting with "name"', () => {
     const rows = parseCsv('name,email,amount,asset\nAlice,,10,XLM');
     expect(rows).toHaveLength(1);
-    expect(rows[0].name).toBe('Alice');
+    expect(rows[0]!.name).toBe('Alice');
   });
 
   it('defaults asset to XLM when column is missing', () => {
     const rows = parseCsv('Alice,,10,');
-    expect(rows[0].assetCode).toBe('XLM');
+    expect(rows[0]!.assetCode).toBe('XLM');
   });
 
   it('strips surrounding quotes from values', () => {
     const rows = parseCsv('"Alice","alice@example.com","10","XLM"');
-    expect(rows[0].name).toBe('Alice');
-    expect(rows[0].email).toBe('alice@example.com');
+    expect(rows[0]!.name).toBe('Alice');
+    expect(rows[0]!.email).toBe('alice@example.com');
   });
 
   it('respects the MAX_ROWS cap of 100', () => {

--- a/frontend/components/batch-send-form.test.tsx
+++ b/frontend/components/batch-send-form.test.tsx
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { BatchSendForm, validateRecipient, parseCsv } from './batch-send-form';
+
+// ── Module mocks ─────────────────────────────────────────────────────────────
+
+const mockConnectFreighter = vi.fn();
+const mockLoadPersistedWallet = vi.fn().mockReturnValue(null);
+const mockPersistWallet = vi.fn();
+const mockCreateEphemeralAccount = vi.fn();
+
+vi.mock('@/lib/wallet', () => ({
+  connectFreighter: () => mockConnectFreighter(),
+  loadPersistedWallet: () => mockLoadPersistedWallet(),
+  persistWallet: (w: unknown) => mockPersistWallet(w),
+  clearPersistedWallet: vi.fn(),
+}));
+
+vi.mock('@/lib/bridgelet', () => ({
+  createEphemeralAccount: (data: unknown) => mockCreateEphemeralAccount(data),
+}));
+
+// ── Pure utility tests ────────────────────────────────────────────────────────
+
+describe('validateRecipient', () => {
+  it('returns no errors for a valid recipient', () => {
+    expect(
+      validateRecipient({ id: '1', name: 'Alice', email: 'alice@example.com', amountXlm: '10', assetCode: 'XLM' }),
+    ).toEqual({});
+  });
+
+  it('returns an error when name is empty', () => {
+    const errors = validateRecipient({ id: '1', name: '', email: '', amountXlm: '10', assetCode: 'XLM' });
+    expect(errors.name).toBeTruthy();
+  });
+
+  it('returns an error for an invalid email', () => {
+    const errors = validateRecipient({ id: '1', name: 'Alice', email: 'not-an-email', amountXlm: '10', assetCode: 'XLM' });
+    expect(errors.email).toBeTruthy();
+  });
+
+  it('accepts an empty email without errors', () => {
+    const errors = validateRecipient({ id: '1', name: 'Alice', email: '', amountXlm: '10', assetCode: 'XLM' });
+    expect(errors.email).toBeUndefined();
+  });
+
+  it('returns an error when amount is 0', () => {
+    const errors = validateRecipient({ id: '1', name: 'Alice', email: '', amountXlm: '0', assetCode: 'XLM' });
+    expect(errors.amountXlm).toBeTruthy();
+  });
+
+  it('returns an error when amount is negative', () => {
+    const errors = validateRecipient({ id: '1', name: 'Alice', email: '', amountXlm: '-5', assetCode: 'XLM' });
+    expect(errors.amountXlm).toBeTruthy();
+  });
+
+  it('returns an error for an unsupported asset', () => {
+    const errors = validateRecipient({ id: '1', name: 'Alice', email: '', amountXlm: '10', assetCode: 'ETH' });
+    expect(errors.assetCode).toBeTruthy();
+  });
+});
+
+describe('parseCsv', () => {
+  it('parses a CSV without a header row', () => {
+    const rows = parseCsv('Alice,alice@example.com,10,XLM\nBob,bob@example.com,5,USDC');
+    expect(rows).toHaveLength(2);
+    expect(rows[0].name).toBe('Alice');
+    expect(rows[1].assetCode).toBe('USDC');
+  });
+
+  it('skips a header row starting with "name"', () => {
+    const rows = parseCsv('name,email,amount,asset\nAlice,,10,XLM');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].name).toBe('Alice');
+  });
+
+  it('defaults asset to XLM when column is missing', () => {
+    const rows = parseCsv('Alice,,10,');
+    expect(rows[0].assetCode).toBe('XLM');
+  });
+
+  it('strips surrounding quotes from values', () => {
+    const rows = parseCsv('"Alice","alice@example.com","10","XLM"');
+    expect(rows[0].name).toBe('Alice');
+    expect(rows[0].email).toBe('alice@example.com');
+  });
+
+  it('respects the MAX_ROWS cap of 100', () => {
+    const lines = Array.from({ length: 110 }, (_, i) => `Recipient${i},,10,XLM`).join('\n');
+    const rows = parseCsv(lines);
+    expect(rows.length).toBeLessThanOrEqual(100);
+  });
+});
+
+// ── Component tests ───────────────────────────────────────────────────────────
+
+describe('BatchSendForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLoadPersistedWallet.mockReturnValue(null);
+  });
+
+  it('renders the wallet connect button when no wallet is persisted', () => {
+    render(<BatchSendForm />);
+    expect(screen.getByRole('button', { name: /connect freighter wallet/i })).toBeInTheDocument();
+  });
+
+  it('restores persisted wallet on mount', async () => {
+    const savedKey = 'G' + 'B'.repeat(55);
+    mockLoadPersistedWallet.mockReturnValue({ publicKey: savedKey, type: 'freighter' });
+    render(<BatchSendForm />);
+    await waitFor(() => {
+      expect(screen.getByText(savedKey)).toBeInTheDocument();
+    });
+  });
+
+  it('renders one empty recipient row by default', () => {
+    render(<BatchSendForm />);
+    // The recipients list container holds one row
+    const list = screen.getByLabelText(/recipients list/i);
+    expect(list.children).toHaveLength(1);
+  });
+
+  it('adds a new row when "Add recipient" is clicked', async () => {
+    const user = userEvent.setup();
+    render(<BatchSendForm />);
+
+    await user.click(screen.getByRole('button', { name: /add recipient/i }));
+    const list = screen.getByLabelText(/recipients list/i);
+    expect(list.children).toHaveLength(2);
+  });
+
+  it('removes a row when the remove button is clicked', async () => {
+    const user = userEvent.setup();
+    render(<BatchSendForm />);
+
+    await user.click(screen.getByRole('button', { name: /add recipient/i }));
+    const list = screen.getByLabelText(/recipients list/i);
+    expect(list.children).toHaveLength(2);
+
+    await user.click(screen.getByRole('button', { name: /remove recipient 2/i }));
+    expect(list.children).toHaveLength(1);
+  });
+
+  it('shows validation errors when submitting with empty fields', async () => {
+    const key = 'G' + 'A'.repeat(55);
+    mockLoadPersistedWallet.mockReturnValue({ publicKey: key, type: 'freighter' });
+    const user = userEvent.setup();
+    render(<BatchSendForm />);
+
+    await waitFor(() => expect(screen.getByText(key)).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: /send to/i }));
+
+    expect(await screen.findByText(/name is required/i)).toBeInTheDocument();
+  });
+
+  it('shows batch progress and success state', async () => {
+    const key = 'G' + 'A'.repeat(55);
+    mockLoadPersistedWallet.mockReturnValue({ publicKey: key, type: 'freighter' });
+    mockCreateEphemeralAccount.mockResolvedValue({
+      claimUrl: 'https://example.com/claim/abc',
+      accountId: 'acc-1',
+    });
+    const user = userEvent.setup();
+    render(<BatchSendForm />);
+
+    await waitFor(() => expect(screen.getByText(key)).toBeInTheDocument());
+
+    // Fill in the one recipient row
+    const list = screen.getByLabelText(/recipients list/i);
+    const row = list.children[0] as HTMLElement;
+    await user.type(within(row).getByLabelText(/^name/i), 'Alice');
+    await user.type(within(row).getByLabelText(/amount/i), '10');
+
+    await user.click(screen.getByRole('button', { name: /send to/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Sent')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('status')).toHaveTextContent(/1 succeeded/i);
+  });
+
+  it('shows error state when account creation fails', async () => {
+    const key = 'G' + 'A'.repeat(55);
+    mockLoadPersistedWallet.mockReturnValue({ publicKey: key, type: 'freighter' });
+    mockCreateEphemeralAccount.mockRejectedValue(new Error('Network error'));
+    const user = userEvent.setup();
+    render(<BatchSendForm />);
+
+    await waitFor(() => expect(screen.getByText(key)).toBeInTheDocument());
+
+    const list = screen.getByLabelText(/recipients list/i);
+    const row = list.children[0] as HTMLElement;
+    await user.type(within(row).getByLabelText(/^name/i), 'Bob');
+    await user.type(within(row).getByLabelText(/amount/i), '5');
+
+    await user.click(screen.getByRole('button', { name: /send to/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/failed: network error/i)).toBeInTheDocument();
+    });
+    expect(screen.getByRole('status')).toHaveTextContent(/1 failed/i);
+  });
+});

--- a/frontend/components/batch-send-form.tsx
+++ b/frontend/components/batch-send-form.tsx
@@ -1,0 +1,614 @@
+'use client';
+
+/**
+ * BatchSendForm — Issue #427: Batch sending to multiple recipients.
+ *
+ * Allows senders to enter multiple recipients via:
+ *   1. Manual row entry (name, email, amount, asset)
+ *   2. CSV paste/upload (name, email, amount, asset)
+ *
+ * Each row is validated before submission. A per-recipient progress UI
+ * shows success/failure as accounts are created sequentially.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  connectFreighter,
+  loadPersistedWallet,
+  persistWallet,
+} from '@/lib/wallet';
+import { createEphemeralAccount } from '@/lib/bridgelet';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface BatchRecipient {
+  id: string;
+  name: string;
+  email: string;
+  amountXlm: string;
+  assetCode: string;
+}
+
+type RecipientStatus = 'pending' | 'processing' | 'success' | 'error';
+
+interface RecipientResult {
+  id: string;
+  status: RecipientStatus;
+  claimUrl?: string;
+  error?: string;
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const DEFAULT_EXPIRES_IN = 7 * 24 * 60 * 60; // 7 days
+const SUPPORTED_ASSETS = ['XLM', 'USDC'] as const;
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MAX_ROWS = 100;
+
+// ─── Validation ──────────────────────────────────────────────────────────────
+
+export interface RecipientError {
+  name?: string;
+  email?: string;
+  amountXlm?: string;
+  assetCode?: string;
+}
+
+export function validateRecipient(r: BatchRecipient): RecipientError {
+  const errors: RecipientError = {};
+  if (!r.name.trim()) errors.name = 'Name is required.';
+  if (r.email.trim() && !EMAIL_RE.test(r.email.trim()))
+    errors.email = 'Enter a valid email or leave empty.';
+  const amt = Number(r.amountXlm);
+  if (!r.amountXlm.trim() || isNaN(amt) || amt <= 0)
+    errors.amountXlm = 'Enter a positive amount.';
+  if (!SUPPORTED_ASSETS.includes(r.assetCode as (typeof SUPPORTED_ASSETS)[number]))
+    errors.assetCode = 'Select an asset.';
+  return errors;
+}
+
+// ─── CSV parsing ─────────────────────────────────────────────────────────────
+
+/**
+ * Parses a CSV string into BatchRecipient rows.
+ * Expected columns (first row = header, ignored):
+ *   name, email, amount, asset
+ */
+export function parseCsv(csv: string): BatchRecipient[] {
+  const lines = csv.trim().split(/\r?\n/).filter(Boolean);
+  // Skip header if first line looks like a header
+  const start = /^name/i.test(lines[0] ?? '') ? 1 : 0;
+  return lines.slice(start, start + MAX_ROWS).map((line, i) => {
+    const [name = '', email = '', amountXlm = '', assetCode = 'XLM'] = line
+      .split(',')
+      .map((c) => c.trim().replace(/^"|"$/g, ''));
+    return {
+      id: `csv-${i}`,
+      name,
+      email,
+      amountXlm,
+      assetCode: assetCode || 'XLM',
+    };
+  });
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function uid() {
+  return Math.random().toString(36).slice(2, 9);
+}
+
+function emptyRow(): BatchRecipient {
+  return { id: uid(), name: '', email: '', amountXlm: '', assetCode: 'XLM' };
+}
+
+interface RecipientRowProps {
+  index: number;
+  recipient: BatchRecipient;
+  errors: RecipientError;
+  result?: RecipientResult;
+  onChange: (patch: Partial<BatchRecipient>) => void;
+  onRemove: () => void;
+  disabled: boolean;
+}
+
+function RecipientRow({
+  index,
+  recipient,
+  errors,
+  result,
+  onChange,
+  onRemove,
+  disabled,
+}: RecipientRowProps) {
+  const rowNum = index + 1;
+
+  return (
+    <div
+      className={`rounded-lg border p-3 transition ${
+        result?.status === 'success'
+          ? 'border-green-300 bg-green-50 dark:border-green-800 dark:bg-green-950'
+          : result?.status === 'error'
+            ? 'border-red-300 bg-red-50 dark:border-red-800 dark:bg-red-950'
+            : result?.status === 'processing'
+              ? 'border-blue-300 bg-blue-50 dark:border-blue-800 dark:bg-blue-950'
+              : 'border-slate-200 dark:border-slate-700'
+      }`}
+      aria-label={`Recipient ${rowNum}`}
+    >
+      <div className="flex items-center justify-between gap-2 mb-2">
+        <span className="text-xs font-semibold text-slate-500 dark:text-slate-400">
+          #{rowNum}
+        </span>
+        {result?.status === 'processing' && (
+          <span className="flex items-center gap-1 text-xs text-blue-700 dark:text-blue-400">
+            <svg className="h-3 w-3 animate-spin" fill="none" viewBox="0 0 24 24">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+            </svg>
+            Processing…
+          </span>
+        )}
+        {result?.status === 'success' && (
+          <span className="flex items-center gap-1 text-xs font-medium text-green-700 dark:text-green-400">
+            <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M5 13l4 4L19 7" />
+            </svg>
+            Sent
+          </span>
+        )}
+        {result?.status === 'error' && (
+          <span className="text-xs font-medium text-red-700 dark:text-red-400" role="alert">
+            Failed: {result.error}
+          </span>
+        )}
+        {!result && (
+          <button
+            type="button"
+            onClick={onRemove}
+            disabled={disabled}
+            aria-label={`Remove recipient ${rowNum}`}
+            className="text-slate-400 hover:text-red-600 disabled:opacity-40 dark:text-slate-500 dark:hover:text-red-400"
+          >
+            <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        {/* Name */}
+        <div>
+          <label
+            htmlFor={`batch-name-${recipient.id}`}
+            className="block text-xs font-medium text-slate-700 dark:text-slate-300"
+          >
+            Name <span className="text-red-500">*</span>
+          </label>
+          <input
+            id={`batch-name-${recipient.id}`}
+            type="text"
+            value={recipient.name}
+            disabled={disabled}
+            onChange={(e) => onChange({ name: e.target.value })}
+            placeholder="e.g. Amina"
+            aria-invalid={!!errors.name}
+            aria-describedby={errors.name ? `batch-name-error-${recipient.id}` : undefined}
+            className={`mt-0.5 block w-full rounded border px-2 py-1.5 text-sm focus:outline-none focus:ring-1 dark:bg-slate-800 dark:text-slate-100 disabled:opacity-60 ${
+              errors.name
+                ? 'border-red-400 focus:border-red-500 focus:ring-red-500'
+                : 'border-slate-300 focus:border-slate-500 focus:ring-slate-500 dark:border-slate-600'
+            }`}
+          />
+          {errors.name && (
+            <p id={`batch-name-error-${recipient.id}`} className="mt-0.5 text-xs text-red-600 dark:text-red-400">
+              {errors.name}
+            </p>
+          )}
+        </div>
+
+        {/* Email */}
+        <div>
+          <label
+            htmlFor={`batch-email-${recipient.id}`}
+            className="block text-xs font-medium text-slate-700 dark:text-slate-300"
+          >
+            Email <span className="text-slate-400 font-normal">(optional)</span>
+          </label>
+          <input
+            id={`batch-email-${recipient.id}`}
+            type="email"
+            value={recipient.email}
+            disabled={disabled}
+            onChange={(e) => onChange({ email: e.target.value })}
+            placeholder="recipient@example.com"
+            aria-invalid={!!errors.email}
+            aria-describedby={errors.email ? `batch-email-error-${recipient.id}` : undefined}
+            className={`mt-0.5 block w-full rounded border px-2 py-1.5 text-sm focus:outline-none focus:ring-1 dark:bg-slate-800 dark:text-slate-100 disabled:opacity-60 ${
+              errors.email
+                ? 'border-red-400 focus:border-red-500 focus:ring-red-500'
+                : 'border-slate-300 focus:border-slate-500 focus:ring-slate-500 dark:border-slate-600'
+            }`}
+          />
+          {errors.email && (
+            <p id={`batch-email-error-${recipient.id}`} className="mt-0.5 text-xs text-red-600 dark:text-red-400">
+              {errors.email}
+            </p>
+          )}
+        </div>
+
+        {/* Amount */}
+        <div>
+          <label
+            htmlFor={`batch-amount-${recipient.id}`}
+            className="block text-xs font-medium text-slate-700 dark:text-slate-300"
+          >
+            Amount <span className="text-red-500">*</span>
+          </label>
+          <div className="mt-0.5 flex gap-1">
+            <input
+              id={`batch-amount-${recipient.id}`}
+              type="number"
+              min="0.0000001"
+              step="any"
+              value={recipient.amountXlm}
+              disabled={disabled}
+              onChange={(e) => onChange({ amountXlm: e.target.value })}
+              placeholder="0.00"
+              aria-invalid={!!errors.amountXlm}
+              aria-describedby={errors.amountXlm ? `batch-amount-error-${recipient.id}` : undefined}
+              className={`block w-full rounded border px-2 py-1.5 text-sm focus:outline-none focus:ring-1 dark:bg-slate-800 dark:text-slate-100 disabled:opacity-60 ${
+                errors.amountXlm
+                  ? 'border-red-400 focus:border-red-500 focus:ring-red-500'
+                  : 'border-slate-300 focus:border-slate-500 focus:ring-slate-500 dark:border-slate-600'
+              }`}
+            />
+            <select
+              aria-label="Asset"
+              value={recipient.assetCode}
+              disabled={disabled}
+              onChange={(e) => onChange({ assetCode: e.target.value })}
+              className="rounded border border-slate-300 px-2 py-1.5 text-sm focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 disabled:opacity-60"
+            >
+              {SUPPORTED_ASSETS.map((a) => (
+                <option key={a} value={a}>{a}</option>
+              ))}
+            </select>
+          </div>
+          {errors.amountXlm && (
+            <p id={`batch-amount-error-${recipient.id}`} className="mt-0.5 text-xs text-red-600 dark:text-red-400">
+              {errors.amountXlm}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* Claim link on success */}
+      {result?.status === 'success' && result.claimUrl && (
+        <div className="mt-2 rounded bg-green-100 px-2 py-1 dark:bg-green-900">
+          <p className="text-xs font-medium text-green-800 dark:text-green-300">Claim link:</p>
+          <a
+            href={result.claimUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="break-all text-xs text-green-700 underline dark:text-green-400"
+          >
+            {result.claimUrl}
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export function BatchSendForm() {
+  const [publicKey, setPublicKey] = useState('');
+  const [walletStatus, setWalletStatus] = useState<'idle' | 'connecting' | 'error'>('idle');
+  const [walletError, setWalletError] = useState<string | null>(null);
+  const [recipients, setRecipients] = useState<BatchRecipient[]>([emptyRow()]);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, RecipientError>>({});
+  const [results, setResults] = useState<Record<string, RecipientResult>>({});
+  const [batchRunning, setBatchRunning] = useState(false);
+  const [batchDone, setBatchDone] = useState(false);
+  const [csvError, setCsvError] = useState<string | null>(null);
+  const csvInputRef = useRef<HTMLInputElement>(null);
+
+  // Restore persisted wallet on mount
+  useEffect(() => {
+    const saved = loadPersistedWallet();
+    if (saved?.publicKey) setPublicKey(saved.publicKey);
+  }, []);
+
+  // ── Wallet ────────────────────────────────────────────────────────────────
+
+  async function handleConnectWallet() {
+    setWalletStatus('connecting');
+    setWalletError(null);
+    try {
+      const wallet = await connectFreighter();
+      persistWallet(wallet);
+      setPublicKey(wallet.publicKey);
+      setWalletStatus('idle');
+    } catch (err) {
+      setWalletStatus('error');
+      setWalletError(
+        err instanceof Error ? err.message : 'Failed to connect wallet. Please try again.',
+      );
+    }
+  }
+
+  // ── Recipient management ──────────────────────────────────────────────────
+
+  function addRow() {
+    if (recipients.length >= MAX_ROWS) return;
+    setRecipients((prev) => [...prev, emptyRow()]);
+  }
+
+  function removeRow(id: string) {
+    setRecipients((prev) => prev.filter((r) => r.id !== id));
+    setFieldErrors((prev) => {
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
+  }
+
+  function updateRow(id: string, patch: Partial<BatchRecipient>) {
+    setRecipients((prev) => prev.map((r) => (r.id === id ? { ...r, ...patch } : r)));
+    // Re-validate on change if already touched
+    if (fieldErrors[id]) {
+      const row = recipients.find((r) => r.id === id)!;
+      setFieldErrors((prev) => ({
+        ...prev,
+        [id]: validateRecipient({ ...row, ...patch }),
+      }));
+    }
+  }
+
+  // ── CSV import ────────────────────────────────────────────────────────────
+
+  const handleCsvUpload = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setCsvError(null);
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      const text = ev.target?.result as string;
+      try {
+        const rows = parseCsv(text);
+        if (rows.length === 0) {
+          setCsvError('No valid rows found in CSV. Expected columns: name, email, amount, asset.');
+          return;
+        }
+        setRecipients(rows);
+        setFieldErrors({});
+        setResults({});
+        setBatchDone(false);
+      } catch {
+        setCsvError('Failed to parse CSV. Please check the format.');
+      }
+    };
+    reader.readAsText(file);
+    // Reset input so the same file can be re-uploaded
+    e.target.value = '';
+  }, []);
+
+  // ── Validation ────────────────────────────────────────────────────────────
+
+  function validateAll(): boolean {
+    const errors: Record<string, RecipientError> = {};
+    let valid = true;
+    for (const r of recipients) {
+      const e = validateRecipient(r);
+      errors[r.id] = e;
+      if (Object.keys(e).length > 0) valid = false;
+    }
+    setFieldErrors(errors);
+    return valid;
+  }
+
+  // ── Batch submission ──────────────────────────────────────────────────────
+
+  async function handleBatchSend() {
+    if (!validateAll()) return;
+    setBatchRunning(true);
+    setBatchDone(false);
+    setResults({});
+
+    for (const recipient of recipients) {
+      setResults((prev) => ({
+        ...prev,
+        [recipient.id]: { id: recipient.id, status: 'processing' },
+      }));
+
+      try {
+        const account = await createEphemeralAccount({
+          fundingSource: publicKey,
+          recovery_address: publicKey,
+          amount: recipient.amountXlm,
+          asset_code: recipient.assetCode !== 'XLM' ? recipient.assetCode : undefined,
+          expiresIn: DEFAULT_EXPIRES_IN,
+          metadata: {
+            recipientName: recipient.name || undefined,
+            recipientEmail: recipient.email || undefined,
+          },
+        });
+        setResults((prev) => ({
+          ...prev,
+          [recipient.id]: {
+            id: recipient.id,
+            status: 'success',
+            claimUrl: account.claimUrl ?? undefined,
+          },
+        }));
+      } catch (err) {
+        setResults((prev) => ({
+          ...prev,
+          [recipient.id]: {
+            id: recipient.id,
+            status: 'error',
+            error: err instanceof Error ? err.message : 'Unexpected error.',
+          },
+        }));
+      }
+    }
+
+    setBatchRunning(false);
+    setBatchDone(true);
+  }
+
+  // ── Derived state ─────────────────────────────────────────────────────────
+
+  const successCount = Object.values(results).filter((r) => r.status === 'success').length;
+  const errorCount = Object.values(results).filter((r) => r.status === 'error').length;
+
+  return (
+    <div className="space-y-6">
+      {/* Wallet connect */}
+      {!publicKey ? (
+        <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800">
+          <p className="text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+            Connect wallet to fund batch payments
+          </p>
+          <button
+            type="button"
+            onClick={handleConnectWallet}
+            disabled={walletStatus === 'connecting'}
+            className="rounded-lg bg-slate-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-700 disabled:opacity-60 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-white"
+          >
+            {walletStatus === 'connecting' ? 'Connecting…' : 'Connect Freighter Wallet'}
+          </button>
+          {walletStatus === 'error' && walletError && (
+            <p role="alert" className="mt-2 text-sm text-red-600 dark:text-red-400">{walletError}</p>
+          )}
+        </div>
+      ) : (
+        <div className="flex items-center gap-3 rounded-lg border border-green-200 bg-green-50 px-4 py-3 dark:border-green-800 dark:bg-green-950">
+          <div className="flex-1">
+            <p className="text-sm font-medium text-green-800 dark:text-green-300">Wallet connected</p>
+            <p className="mt-0.5 break-all font-mono text-xs text-green-700 dark:text-green-400">{publicKey}</p>
+          </div>
+        </div>
+      )}
+
+      {/* CSV import */}
+      <div className="flex flex-wrap items-center gap-3">
+        <span className="text-sm font-medium text-slate-700 dark:text-slate-300">Import recipients:</span>
+        <label
+          htmlFor="csv-upload"
+          className="cursor-pointer rounded-lg border border-dashed border-slate-300 px-3 py-1.5 text-sm text-slate-600 hover:border-slate-500 hover:text-slate-800 dark:border-slate-600 dark:text-slate-400 dark:hover:border-slate-400 dark:hover:text-slate-200"
+        >
+          Upload CSV
+        </label>
+        <input
+          id="csv-upload"
+          ref={csvInputRef}
+          type="file"
+          accept=".csv,text/csv"
+          onChange={handleCsvUpload}
+          className="sr-only"
+          aria-label="Upload CSV file with recipient list"
+        />
+        <span className="text-xs text-slate-500 dark:text-slate-400">
+          Columns: <code className="font-mono">name, email, amount, asset</code>
+        </span>
+      </div>
+      {csvError && (
+        <p role="alert" className="text-sm text-red-600 dark:text-red-400">{csvError}</p>
+      )}
+
+      {/* Recipient rows */}
+      <div className="space-y-3" aria-label="Recipients list">
+        {recipients.map((r, i) => (
+          <RecipientRow
+            key={r.id}
+            index={i}
+            recipient={r}
+            errors={fieldErrors[r.id] ?? {}}
+            result={results[r.id]}
+            onChange={(patch) => updateRow(r.id, patch)}
+            onRemove={() => removeRow(r.id)}
+            disabled={batchRunning}
+          />
+        ))}
+      </div>
+
+      {/* Add row */}
+      {!batchRunning && !batchDone && (
+        <button
+          type="button"
+          onClick={addRow}
+          disabled={recipients.length >= MAX_ROWS}
+          className="flex items-center gap-1.5 rounded-lg border border-dashed border-slate-300 px-3 py-2 text-sm text-slate-600 hover:border-slate-500 hover:text-slate-800 disabled:opacity-40 dark:border-slate-600 dark:text-slate-400 dark:hover:border-slate-400 dark:hover:text-slate-200"
+        >
+          <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 4v16m8-8H4" />
+          </svg>
+          Add recipient
+        </button>
+      )}
+
+      {/* Batch progress summary */}
+      {batchDone && (
+        <div
+          role="status"
+          aria-live="polite"
+          className={`rounded-lg border p-4 ${
+            errorCount === 0
+              ? 'border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950'
+              : 'border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950'
+          }`}
+        >
+          <p className={`text-sm font-medium ${errorCount === 0 ? 'text-green-800 dark:text-green-300' : 'text-amber-800 dark:text-amber-300'}`}>
+            Batch complete
+          </p>
+          <p className="mt-1 text-sm text-slate-700 dark:text-slate-300">
+            {successCount} succeeded, {errorCount} failed out of {recipients.length} total.
+          </p>
+        </div>
+      )}
+
+      {/* Send button */}
+      {!batchDone && (
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={handleBatchSend}
+            disabled={batchRunning || !publicKey || recipients.length === 0}
+            className="rounded-lg bg-slate-900 px-5 py-2.5 text-sm font-medium text-white transition hover:bg-slate-700 disabled:opacity-60 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-white"
+          >
+            {batchRunning
+              ? `Sending (${Object.values(results).filter((r) => r.status !== 'pending').length}/${recipients.length})…`
+              : `Send to ${recipients.length} recipient${recipients.length !== 1 ? 's' : ''}`}
+          </button>
+          {batchRunning && (
+            <span className="text-sm text-slate-500 dark:text-slate-400" aria-live="polite">
+              {successCount} sent, {errorCount} failed
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Retry failed */}
+      {batchDone && errorCount > 0 && (
+        <button
+          type="button"
+          onClick={() => {
+            setBatchDone(false);
+            // Keep only failed recipients for retry
+            setRecipients((prev) =>
+              prev.filter((r) => results[r.id]?.status !== 'success'),
+            );
+            setResults({});
+          }}
+          className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-700"
+        >
+          Retry {errorCount} failed
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/send-form/index.tsx
+++ b/frontend/components/send-form/index.tsx
@@ -120,7 +120,9 @@ export function SendForm() {
           publicKey={formState.publicKey}
           onConnected={(key) => {
             updateState({ publicKey: key });
-            goNext();
+            // Only advance when a real key was provided; an empty string means
+            // the user disconnected their wallet (persisted state cleared).
+            if (key) goNext();
           }}
         />
       )}

--- a/frontend/components/send-form/steps/confirm-step.tsx
+++ b/frontend/components/send-form/steps/confirm-step.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import type { SendFormState } from '../index';
 import { useNfc } from '@/hooks/use-nfc';
 import { BridgeletClient, RateLimitError } from '@/lib/api/client';
 import { createEphemeralAccount, type EphemeralAccount } from '@/lib/bridgelet';
+import { estimateCreateAccountFee } from '@/lib/fee-estimation';
+import { getXlmUsdRate } from '@/lib/xlm-price';
 import {
   FreighterSenderSigningError,
   toCreateAccountRequestWithFreighterSignature,
@@ -58,6 +60,12 @@ type ConfirmStepProps = {
 
 type SubmitPhase = 'idle' | 'preparing' | 'awaiting-freighter' | 'submitting' | 'success';
 
+interface FeeDisplay {
+  xlm: string;
+  fiat: string | null;
+  capacityUsage: number;
+}
+
 export function ConfirmStep({ state, onBack }: ConfirmStepProps) {
   const [submitPhase, setSubmitPhase] = useState<SubmitPhase>('idle');
   const [signingModeUsed, setSigningModeUsed] = useState<'freighter-client' | 'backend' | null>(
@@ -68,6 +76,34 @@ export function ConfirmStep({ state, onBack }: ConfirmStepProps) {
   const [retryAfter, setRetryAfter] = useState<number | null>(null);
   const [claimUrl, setClaimUrl] = useState<string | null>(null);
   const { isSupported, writeUrl, isWriting, error: nfcError } = useNfc();
+
+  // Fee estimation state
+  const [feeDisplay, setFeeDisplay] = useState<FeeDisplay | null>(null);
+  const [feeLoading, setFeeLoading] = useState(true);
+  const [feeError, setFeeError] = useState<string | null>(null);
+
+  const fetchFee = useCallback(async () => {
+    setFeeLoading(true);
+    setFeeError(null);
+    try {
+      const xlmRate = await getXlmUsdRate();
+      const fee = await estimateCreateAccountFee(xlmRate > 0 ? xlmRate : null);
+      setFeeDisplay({ xlm: fee.xlm, fiat: fee.fiat, capacityUsage: fee.capacityUsage });
+    } catch {
+      setFeeError('Could not fetch fee estimate. Network fee may apply.');
+    } finally {
+      setFeeLoading(false);
+    }
+  }, []);
+
+  // Fetch fee on mount and refresh every 30 seconds while idle
+  useEffect(() => {
+    fetchFee();
+    const interval = setInterval(() => {
+      if (submitPhase === 'idle') fetchFee();
+    }, 30_000);
+    return () => clearInterval(interval);
+  }, [fetchFee, submitPhase]);
 
   const submitting = submitPhase !== 'idle' && submitPhase !== 'success';
 
@@ -244,11 +280,76 @@ export function ConfirmStep({ state, onBack }: ConfirmStepProps) {
             <dd className="text-slate-600 dark:text-slate-400">{state.memo}</dd>
           </div>
         )}
+        {/* Issue #425 — expiry summary */}
+        <div className="flex justify-between py-1.5">
+          <dt className="font-medium text-slate-700 dark:text-slate-300">Claim expires</dt>
+          <dd className="text-slate-600 dark:text-slate-400">
+            {formatExpiryLabel(state.expiresIn || DEFAULT_EXPIRES_IN_SECONDS)} from now
+          </dd>
+        </div>
         <div className="flex justify-between py-1.5">
           <dt className="font-medium text-slate-700 dark:text-slate-300">Signing</dt>
           <dd className="text-slate-600 dark:text-slate-400">Freighter (experimental) with backend fallback</dd>
         </div>
       </dl>
+
+      {/* Issue #426 — fee estimation */}
+      <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800">
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-medium text-slate-700 dark:text-slate-300">
+            Estimated network fee
+          </span>
+          <button
+            type="button"
+            onClick={fetchFee}
+            disabled={feeLoading}
+            aria-label="Refresh fee estimate"
+            className="rounded p-0.5 text-slate-400 hover:text-slate-700 disabled:opacity-40 dark:text-slate-500 dark:hover:text-slate-200"
+          >
+            {/* Refresh icon */}
+            <svg
+              className={`h-4 w-4 ${feeLoading ? 'animate-spin' : ''}`}
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+              />
+            </svg>
+          </button>
+        </div>
+
+        <div aria-live="polite" className="mt-1">
+          {feeLoading && (
+            <p className="text-sm text-slate-500 dark:text-slate-400">Fetching fee estimate…</p>
+          )}
+          {!feeLoading && feeError && (
+            <p className="text-sm text-amber-700 dark:text-amber-400">{feeError}</p>
+          )}
+          {!feeLoading && feeDisplay && (
+            <div className="space-y-0.5">
+              <p className="text-sm font-medium text-slate-800 dark:text-slate-200">
+                {feeDisplay.xlm} XLM
+                {feeDisplay.fiat && (
+                  <span className="ml-2 font-normal text-slate-500 dark:text-slate-400">
+                    {feeDisplay.fiat}
+                  </span>
+                )}
+              </p>
+              {feeDisplay.capacityUsage > 0.8 && (
+                <p className="text-xs text-amber-700 dark:text-amber-400">
+                  Network is currently busy — fees may be higher than usual.
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
 
       {errorInfo && (
         <div role="alert" className="rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-950">

--- a/frontend/components/send-form/steps/connect-step.test.tsx
+++ b/frontend/components/send-form/steps/connect-step.test.tsx
@@ -9,43 +9,94 @@ vi.mock('@/components/chain-selector', () => ({
 }));
 
 const mockConnectFreighter = vi.fn();
+const mockPersistWallet = vi.fn();
+const mockLoadPersistedWallet = vi.fn().mockReturnValue(null);
+const mockClearPersistedWallet = vi.fn();
+
 vi.mock('@/lib/wallet', () => ({
   connectFreighter: () => mockConnectFreighter(),
+  persistWallet: (w: unknown) => mockPersistWallet(w),
+  loadPersistedWallet: () => mockLoadPersistedWallet(),
+  clearPersistedWallet: () => mockClearPersistedWallet(),
 }));
 
 describe('ConnectStep', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockLoadPersistedWallet.mockReturnValue(null);
   });
 
   // ── Pre-connected (publicKey already set) ────────────────────────────────
 
   it('shows the connected wallet address when publicKey is provided', () => {
     const key = 'G' + 'A'.repeat(55);
-    render(<ConnectStep publicKey={key} onConnected={vi.fn()} />);
+    render(<ConnectStep publicKey={key} onConnected={vi.fn()} extensionSupportedOverride={true} />);
     expect(screen.getByText('Wallet connected')).toBeInTheDocument();
     expect(screen.getByText(key)).toBeInTheDocument();
   });
 
   it('does not render the connect button when already connected', () => {
-    render(<ConnectStep publicKey={'G' + 'A'.repeat(55)} onConnected={vi.fn()} />);
+    render(<ConnectStep publicKey={'G' + 'A'.repeat(55)} onConnected={vi.fn()} extensionSupportedOverride={true} />);
     expect(screen.queryByRole('button', { name: /connect freighter/i })).not.toBeInTheDocument();
+  });
+
+  it('shows a disconnect button when wallet is connected', () => {
+    render(<ConnectStep publicKey={'G' + 'A'.repeat(55)} onConnected={vi.fn()} extensionSupportedOverride={true} />);
+    expect(screen.getByRole('button', { name: /disconnect wallet/i })).toBeInTheDocument();
+  });
+
+  it('calls onConnected with empty string and clearPersistedWallet when disconnecting', async () => {
+    const onConnected = vi.fn();
+    const user = userEvent.setup();
+    render(<ConnectStep publicKey={'G' + 'A'.repeat(55)} onConnected={onConnected} extensionSupportedOverride={true} />);
+
+    await user.click(screen.getByRole('button', { name: /disconnect wallet/i }));
+
+    expect(mockClearPersistedWallet).toHaveBeenCalledTimes(1);
+    expect(onConnected).toHaveBeenCalledWith('');
+  });
+
+  // ── Wallet persistence ───────────────────────────────────────────────────
+
+  it('calls onConnected with persisted wallet key on mount if no publicKey is set', async () => {
+    const savedKey = 'G' + 'B'.repeat(55);
+    mockLoadPersistedWallet.mockReturnValue({ publicKey: savedKey, type: 'freighter' });
+    const onConnected = vi.fn();
+
+    render(<ConnectStep publicKey="" onConnected={onConnected} extensionSupportedOverride={true} />);
+
+    await waitFor(() => expect(onConnected).toHaveBeenCalledWith(savedKey));
+  });
+
+  it('does not call onConnected on mount when publicKey is already set', async () => {
+    const onConnected = vi.fn();
+    render(<ConnectStep publicKey={'G' + 'A'.repeat(55)} onConnected={onConnected} extensionSupportedOverride={true} />);
+
+    // Give the effect time to fire
+    await new Promise((r) => setTimeout(r, 50));
+    expect(onConnected).not.toHaveBeenCalled();
   });
 
   // ── Disconnected state ───────────────────────────────────────────────────
 
   it('renders the connect button and chain selector when no publicKey', () => {
-    render(<ConnectStep publicKey="" onConnected={vi.fn()} />);
+    render(<ConnectStep publicKey="" onConnected={vi.fn()} extensionSupportedOverride={true} />);
     expect(screen.getByRole('button', { name: /connect freighter wallet/i })).toBeInTheDocument();
     expect(screen.getByTestId('chain-selector')).toBeInTheDocument();
   });
 
   it('renders an Install Freighter link pointing to the docs', () => {
-    render(<ConnectStep publicKey="" onConnected={vi.fn()} />);
+    render(<ConnectStep publicKey="" onConnected={vi.fn()} extensionSupportedOverride={true} />);
     const link = screen.getByRole('link', { name: /install freighter/i });
     expect(link).toHaveAttribute('href', 'https://docs.freighter.app');
     expect(link).toHaveAttribute('target', '_blank');
     expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('shows unsupported browser fallback when extension is not supported', () => {
+    render(<ConnectStep publicKey="" onConnected={vi.fn()} extensionSupportedOverride={false} />);
+    expect(screen.queryByRole('button', { name: /connect freighter wallet/i })).not.toBeInTheDocument();
+    expect(screen.getByText(/browser not supported/i)).toBeInTheDocument();
   });
 
   // ── Successful connection ────────────────────────────────────────────────
@@ -56,10 +107,22 @@ describe('ConnectStep', () => {
     const onConnected = vi.fn();
     const user = userEvent.setup();
 
-    render(<ConnectStep publicKey="" onConnected={onConnected} />);
+    render(<ConnectStep publicKey="" onConnected={onConnected} extensionSupportedOverride={true} />);
     await user.click(screen.getByRole('button', { name: /connect freighter wallet/i }));
 
     await waitFor(() => expect(onConnected).toHaveBeenCalledWith(publicKey));
+  });
+
+  it('persists wallet after successful connection', async () => {
+    const publicKey = 'G' + 'B'.repeat(55);
+    const wallet = { publicKey, type: 'freighter' as const };
+    mockConnectFreighter.mockResolvedValue(wallet);
+    const user = userEvent.setup();
+
+    render(<ConnectStep publicKey="" onConnected={vi.fn()} extensionSupportedOverride={true} />);
+    await user.click(screen.getByRole('button', { name: /connect freighter wallet/i }));
+
+    await waitFor(() => expect(mockPersistWallet).toHaveBeenCalledWith(wallet));
   });
 
   it('shows "Connecting…" while the wallet request is in flight', async () => {
@@ -67,7 +130,7 @@ describe('ConnectStep', () => {
     mockConnectFreighter.mockReturnValue(new Promise((r) => { resolve = r; }));
     const user = userEvent.setup();
 
-    render(<ConnectStep publicKey="" onConnected={vi.fn()} />);
+    render(<ConnectStep publicKey="" onConnected={vi.fn()} extensionSupportedOverride={true} />);
     await user.click(screen.getByRole('button', { name: /connect freighter wallet/i }));
 
     expect(await screen.findByRole('button', { name: /connecting…/i })).toBeDisabled();
@@ -80,17 +143,27 @@ describe('ConnectStep', () => {
     mockConnectFreighter.mockRejectedValue(new Error('Freighter not installed'));
     const user = userEvent.setup();
 
-    render(<ConnectStep publicKey="" onConnected={vi.fn()} />);
+    render(<ConnectStep publicKey="" onConnected={vi.fn()} extensionSupportedOverride={true} />);
     await user.click(screen.getByRole('button', { name: /connect freighter wallet/i }));
 
     expect(await screen.findByRole('alert')).toHaveTextContent('Freighter not installed');
+  });
+
+  it('shows a clear rejection message when the user declines the prompt', async () => {
+    mockConnectFreighter.mockRejectedValue(new Error('User rejected the request'));
+    const user = userEvent.setup();
+
+    render(<ConnectStep publicKey="" onConnected={vi.fn()} extensionSupportedOverride={true} />);
+    await user.click(screen.getByRole('button', { name: /connect freighter wallet/i }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/declined/i);
   });
 
   it('shows a generic fallback message for non-Error rejections', async () => {
     mockConnectFreighter.mockRejectedValue('unexpected');
     const user = userEvent.setup();
 
-    render(<ConnectStep publicKey="" onConnected={vi.fn()} />);
+    render(<ConnectStep publicKey="" onConnected={vi.fn()} extensionSupportedOverride={true} />);
     await user.click(screen.getByRole('button', { name: /connect freighter wallet/i }));
 
     expect(await screen.findByRole('alert')).toHaveTextContent(/failed to connect wallet/i);
@@ -100,7 +173,7 @@ describe('ConnectStep', () => {
     mockConnectFreighter.mockRejectedValue(new Error('fail'));
     const user = userEvent.setup();
 
-    render(<ConnectStep publicKey="" onConnected={vi.fn()} />);
+    render(<ConnectStep publicKey="" onConnected={vi.fn()} extensionSupportedOverride={true} />);
     await user.click(screen.getByRole('button', { name: /connect freighter wallet/i }));
 
     await waitFor(() =>

--- a/frontend/components/send-form/steps/connect-step.tsx
+++ b/frontend/components/send-form/steps/connect-step.tsx
@@ -35,9 +35,21 @@ function isBrowserExtensionSupported(): boolean {
 export function ConnectStep({ publicKey, onConnected, extensionSupportedOverride }: ConnectStepProps) {
   const [status, setStatus] = useState<'idle' | 'connecting' | 'error'>('idle');
   const [error, setError] = useState<string | null>(null);
-  const [extensionSupported] = useState<boolean>(() =>
-    extensionSupportedOverride !== undefined ? extensionSupportedOverride : isBrowserExtensionSupported(),
-  );
+
+  // Start with `true` so server-rendered HTML always shows the connect button.
+  // After the client hydrates we re-check and may switch to the fallback banner.
+  // This prevents a hydration mismatch because both server and client agree on
+  // the initial render; the fallback only appears after a client-side effect.
+  const [extensionSupported, setExtensionSupported] = useState<boolean>(true);
+
+  useEffect(() => {
+    if (extensionSupportedOverride !== undefined) {
+      setExtensionSupported(extensionSupportedOverride);
+    } else {
+      setExtensionSupported(isBrowserExtensionSupported());
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // intentionally runs once after mount
 
   // On mount, restore a previously persisted wallet so the user doesn't
   // have to re-connect every time they navigate back through the flow.

--- a/frontend/components/send-form/steps/connect-step.tsx
+++ b/frontend/components/send-form/steps/connect-step.tsx
@@ -1,38 +1,108 @@
 'use client';
 
-import { useState } from 'react';
-import { connectFreighter } from '@/lib/wallet';
+import { useEffect, useState } from 'react';
+import {
+  connectFreighter,
+  loadPersistedWallet,
+  persistWallet,
+  clearPersistedWallet,
+} from '@/lib/wallet';
 import { ChainSelector } from '@/components/chain-selector';
 
 type ConnectStepProps = {
   publicKey: string;
   onConnected: (publicKey: string) => void;
+  /** Override browser extension detection for tests. Defaults to auto-detect. */
+  extensionSupportedOverride?: boolean;
 };
 
-export function ConnectStep({ publicKey, onConnected }: ConnectStepProps) {
+/**
+ * Detects whether we are running in a browser context that supports
+ * browser extensions (i.e. a real Chromium/Firefox desktop browser).
+ * On platforms such as Safari mobile, in-app webviews, or non-extension
+ * environments, Freighter cannot be installed, so we skip the
+ * extension-install prompt and suggest an alternative.
+ */
+function isBrowserExtensionSupported(): boolean {
+  if (typeof window === 'undefined') return false;
+  // navigator.userAgent is available in every browser; the presence of
+  // "Chrome" or "Firefox" in the UA string is a coarse but practical signal
+  // that the user is in a desktop browser where extensions can be installed.
+  const ua = navigator.userAgent;
+  return /Chrome\//.test(ua) || /Firefox\//.test(ua) || /Edg\//.test(ua);
+}
+
+export function ConnectStep({ publicKey, onConnected, extensionSupportedOverride }: ConnectStepProps) {
   const [status, setStatus] = useState<'idle' | 'connecting' | 'error'>('idle');
   const [error, setError] = useState<string | null>(null);
+  const [extensionSupported] = useState<boolean>(() =>
+    extensionSupportedOverride !== undefined ? extensionSupportedOverride : isBrowserExtensionSupported(),
+  );
+
+  // On mount, restore a previously persisted wallet so the user doesn't
+  // have to re-connect every time they navigate back through the flow.
+  useEffect(() => {
+    if (publicKey) return; // parent already has a key — nothing to restore
+    const saved = loadPersistedWallet();
+    if (saved?.publicKey) {
+      onConnected(saved.publicKey);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // intentionally runs once on mount only
 
   async function handleConnect() {
     setStatus('connecting');
     setError(null);
     try {
       const wallet = await connectFreighter();
+      persistWallet(wallet);
       setStatus('idle');
       onConnected(wallet.publicKey);
     } catch (err) {
       setStatus('error');
-      setError(err instanceof Error ? err.message : 'Failed to connect wallet.');
+      if (err instanceof Error) {
+        // Surface rejection errors clearly to distinguish from "not installed"
+        if (
+          err.message.toLowerCase().includes('user declined') ||
+          err.message.toLowerCase().includes('rejected') ||
+          err.message.toLowerCase().includes('did not return a public key')
+        ) {
+          setError(
+            'Connection request was declined. Please approve the Freighter prompt and try again.',
+          );
+        } else {
+          setError(err.message);
+        }
+      } else {
+        setError('Failed to connect wallet. Please try again.');
+      }
     }
+  }
+
+  function handleDisconnect() {
+    clearPersistedWallet();
+    // Inform parent that the key is cleared by calling with empty string
+    onConnected('');
   }
 
   if (publicKey) {
     return (
-      <div className="rounded-lg border border-green-200 bg-green-50 px-4 py-3 dark:border-green-800 dark:bg-green-950">
-        <p className="text-sm font-medium text-green-800 dark:text-green-300">Wallet connected</p>
-        <p className="mt-0.5 break-all font-mono text-xs text-green-700 dark:text-green-400">
-          {publicKey}
-        </p>
+      <div className="space-y-3">
+        <div className="rounded-lg border border-green-200 bg-green-50 px-4 py-3 dark:border-green-800 dark:bg-green-950">
+          <p className="text-sm font-medium text-green-800 dark:text-green-300">
+            Wallet connected
+          </p>
+          <p className="mt-0.5 break-all font-mono text-xs text-green-700 dark:text-green-400">
+            {publicKey}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={handleDisconnect}
+          className="text-xs text-slate-500 underline underline-offset-2 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
+        >
+          Disconnect wallet
+        </button>
       </div>
     );
   }
@@ -47,29 +117,53 @@ export function ConnectStep({ publicKey, onConnected }: ConnectStepProps) {
       <div className="py-2">
         <ChainSelector />
       </div>
-      <button
-        type="button"
-        onClick={handleConnect}
-        disabled={status === 'connecting'}
-        className="rounded-lg bg-slate-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-700 disabled:opacity-60 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-white"
-      >
-        {status === 'connecting' ? 'Connecting…' : 'Connect Freighter Wallet'}
-      </button>
-      {status === 'error' && error && (
-        <p role="alert" className="text-sm text-red-600 dark:text-red-400">
-          {error}
-        </p>
+
+      {extensionSupported ? (
+        <>
+          <button
+            type="button"
+            onClick={handleConnect}
+            disabled={status === 'connecting'}
+            className="rounded-lg bg-slate-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-700 disabled:opacity-60 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-white"
+          >
+            {status === 'connecting' ? 'Connecting…' : 'Connect Freighter Wallet'}
+          </button>
+          {status === 'error' && error && (
+            <p role="alert" className="text-sm text-red-600 dark:text-red-400">
+              {error}
+            </p>
+          )}
+          <p className="text-xs text-slate-500 dark:text-slate-400">
+            Don&apos;t have Freighter?{' '}
+            <a
+              href="https://docs.freighter.app"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline underline-offset-2 hover:text-slate-800 dark:hover:text-slate-200"
+            >
+              Install Freighter
+            </a>
+          </p>
+        </>
+      ) : (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-950">
+          <p className="text-sm font-medium text-amber-800 dark:text-amber-300">
+            Browser not supported for wallet extensions
+          </p>
+          <p className="mt-1 text-sm text-amber-700 dark:text-amber-400">
+            Freighter is a browser extension for Chrome, Firefox, and Edge. Please open this page
+            in a supported desktop browser to connect your wallet.
+          </p>
+          <a
+            href="https://docs.freighter.app"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-2 inline-block text-xs font-medium text-amber-800 underline underline-offset-2 hover:text-amber-900 dark:text-amber-300 dark:hover:text-amber-200"
+          >
+            Learn about Freighter →
+          </a>
+        </div>
       )}
-      <p className="text-xs text-slate-500 dark:text-slate-400">
-        <a
-          href="https://docs.freighter.app"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="underline underline-offset-2 hover:text-slate-800 dark:hover:text-slate-200"
-        >
-          Install Freighter
-        </a>
-      </p>
     </div>
   );
 }

--- a/frontend/components/send-form/steps/connect-step.tsx
+++ b/frontend/components/send-form/steps/connect-step.tsx
@@ -36,17 +36,24 @@ export function ConnectStep({ publicKey, onConnected, extensionSupportedOverride
   const [status, setStatus] = useState<'idle' | 'connecting' | 'error'>('idle');
   const [error, setError] = useState<string | null>(null);
 
-  // Start with `true` so server-rendered HTML always shows the connect button.
-  // After the client hydrates we re-check and may switch to the fallback banner.
-  // This prevents a hydration mismatch because both server and client agree on
-  // the initial render; the fallback only appears after a client-side effect.
+  // Start with `true` so server-rendered HTML always shows the connect button,
+  // preventing a hydration mismatch (useState lazy initializers run on the server
+  // in Next.js App Router SSR). After mount we only switch to `false` when the
+  // environment genuinely doesn't support extensions — never back to `true` —
+  // so no spurious re-render occurs in Chromium where the check returns `true`.
   const [extensionSupported, setExtensionSupported] = useState<boolean>(true);
 
   useEffect(() => {
-    if (extensionSupportedOverride !== undefined) {
-      setExtensionSupported(extensionSupportedOverride);
-    } else {
-      setExtensionSupported(isBrowserExtensionSupported());
+    const supported =
+      extensionSupportedOverride !== undefined
+        ? extensionSupportedOverride
+        : isBrowserExtensionSupported();
+    // Only update (and re-render) when the result is false — i.e. we need to
+    // swap from the connect button to the fallback banner. In Chromium this is
+    // always true so setExtensionSupported is never called and the button stays
+    // stable in the DOM, which is critical for Playwright click reliability.
+    if (!supported) {
+      setExtensionSupported(false);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // intentionally runs once after mount

--- a/frontend/components/send-page-client.tsx
+++ b/frontend/components/send-page-client.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useState } from 'react';
+import { SendForm } from '@/components/send-form';
+import { BatchSendForm } from '@/components/batch-send-form';
+
+type SendMode = 'single' | 'batch';
+
+/**
+ * Client wrapper for the /send page.
+ *
+ * Lets the sender choose between:
+ *   - Single recipient — the existing multi-step SendForm
+ *   - Batch recipients — the new BatchSendForm (Issue #427)
+ */
+export function SendPageClient() {
+  const [mode, setMode] = useState<SendMode>('single');
+
+  return (
+    <div className="space-y-6">
+      {/* Mode toggle */}
+      <div className="flex gap-1 rounded-lg border border-slate-200 bg-slate-50 p-1 dark:border-slate-700 dark:bg-slate-800 w-fit">
+        <button
+          type="button"
+          onClick={() => setMode('single')}
+          aria-pressed={mode === 'single'}
+          className={`rounded px-4 py-1.5 text-sm font-medium transition ${
+            mode === 'single'
+              ? 'bg-white shadow-sm text-slate-900 dark:bg-slate-700 dark:text-slate-100'
+              : 'text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200'
+          }`}
+        >
+          Single recipient
+        </button>
+        <button
+          type="button"
+          onClick={() => setMode('batch')}
+          aria-pressed={mode === 'batch'}
+          className={`rounded px-4 py-1.5 text-sm font-medium transition ${
+            mode === 'batch'
+              ? 'bg-white shadow-sm text-slate-900 dark:bg-slate-700 dark:text-slate-100'
+              : 'text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200'
+          }`}
+        >
+          Batch recipients
+        </button>
+      </div>
+
+      {mode === 'single' ? (
+        <SendForm />
+      ) : (
+        <div>
+          <p className="mb-4 text-sm text-slate-600 dark:text-slate-400">
+            Send to multiple recipients at once. Add rows manually or upload a CSV with columns:{' '}
+            <code className="rounded bg-slate-100 px-1 py-0.5 font-mono text-xs dark:bg-slate-800">
+              name, email, amount, asset
+            </code>
+            . Each recipient gets an independent claim link. The default claim window is{' '}
+            <strong>7 days</strong>.
+          </p>
+          <BatchSendForm />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/lib/fee-estimation.test.ts
+++ b/frontend/lib/fee-estimation.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { estimateCreateAccountFee, clearFeeCache } from '@/lib/fee-estimation';
+
+const feeStatsJson = {
+  last_ledger_base_fee: '100',
+  ledger_capacity_usage: '0.42',
+  fee_charged: { p50: '100' },
+  max_fee: { p50: '500' },
+};
+
+describe('estimateCreateAccountFee', () => {
+  beforeEach(() => {
+    clearFeeCache();
+    vi.restoreAllMocks();
+  });
+
+  it('returns fee in XLM and fiat when a rate is provided', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => feeStatsJson,
+      }),
+    );
+
+    const result = await estimateCreateAccountFee(0.1, 2);
+
+    // 500 stroops/op × 2 ops = 1000 stroops = 0.0001000 XLM
+    // 0.0001 XLM × $0.1/XLM = $0.00001
+    expect(result.stroops).toBe(1000);
+    expect(result.xlm).toBe('0.0001000');
+    expect(result.fiat).toMatch(/\$0\.000010/);
+  });
+
+  it('returns null fiat when no rate is provided', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => feeStatsJson,
+      }),
+    );
+
+    const result = await estimateCreateAccountFee(null, 2);
+
+    expect(result.fiat).toBeNull();
+  });
+
+  it('respects the opCount parameter', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => feeStatsJson,
+      }),
+    );
+
+    const result1 = await estimateCreateAccountFee(null, 1);
+    clearFeeCache();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => feeStatsJson,
+      }),
+    );
+    const result2 = await estimateCreateAccountFee(null, 4);
+
+    expect(result2.stroops).toBe(result1.stroops * 4);
+  });
+
+  it('throws when the Horizon request fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+      }),
+    );
+
+    await expect(estimateCreateAccountFee()).rejects.toThrow('503');
+  });
+
+  it('caches fee stats and does not fetch again within cache window', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => feeStatsJson,
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await estimateCreateAccountFee();
+    await estimateCreateAccountFee();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns correct capacity usage', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ ...feeStatsJson, ledger_capacity_usage: '0.85' }),
+      }),
+    );
+
+    const result = await estimateCreateAccountFee();
+    expect(result.capacityUsage).toBeCloseTo(0.85);
+  });
+});

--- a/frontend/lib/fee-estimation.ts
+++ b/frontend/lib/fee-estimation.ts
@@ -1,0 +1,87 @@
+/**
+ * Fee estimation utilities for Stellar network.
+ *
+ * Fetches current fee statistics from Horizon and returns a human-readable
+ * estimate. Results are cached briefly to avoid hammering the API.
+ *
+ * The "base fee" (p50 of max_fee) is the most commonly used figure — it
+ * represents what most senders offer. One ephemeral-account creation is a
+ * single transaction with 1–2 operations, so we multiply by `opCount`.
+ */
+
+const HORIZON_BASE_URL =
+  process.env['NEXT_PUBLIC_HORIZON_URL'] ?? 'https://horizon-testnet.stellar.org';
+
+const STROOPS_PER_XLM = 10_000_000;
+const CACHE_MS = 30_000; // 30-second cache for fee stats
+
+interface HorizonFeeStats {
+  last_ledger_base_fee: string;
+  fee_charged: { p50: string };
+  max_fee: { p50: string };
+}
+
+interface FeeEstimate {
+  /** Fee in stroops (integer) */
+  stroops: number;
+  /** Fee in XLM (formatted string, e.g. "0.0000100") */
+  xlm: string;
+  /** Fee in USD (formatted string, e.g. "≈ $0.000003") or null if rate unavailable */
+  fiat: string | null;
+  /** Ledger capacity usage 0–1 */
+  capacityUsage: number;
+}
+
+let feeCache: { data: HorizonFeeStats; at: number } | null = null;
+
+async function fetchFeeStats(): Promise<HorizonFeeStats> {
+  if (feeCache && Date.now() - feeCache.at < CACHE_MS) {
+    return feeCache.data;
+  }
+  const res = await fetch(`${HORIZON_BASE_URL}/fee_stats`, { cache: 'no-store' });
+  if (!res.ok) throw new Error(`Horizon /fee_stats returned ${res.status}`);
+  const data = (await res.json()) as HorizonFeeStats;
+  feeCache = { data, at: Date.now() };
+  return data;
+}
+
+/**
+ * Returns a fee estimate for creating one ephemeral account.
+ * `xlmRate` — optional XLM/USD exchange rate; pass null to skip fiat display.
+ * `opCount` — number of operations in the transaction (default 2: create + fund).
+ */
+export async function estimateCreateAccountFee(
+  xlmRate: number | null = null,
+  opCount = 2,
+): Promise<FeeEstimate> {
+  const stats = await fetchFeeStats();
+
+  // p50 of max_fee is a reasonable "recommended" fee per operation
+  const feePerOp = parseInt(stats.max_fee?.p50 ?? stats.last_ledger_base_fee, 10);
+  const totalStroops = feePerOp * opCount;
+  const totalXlm = totalStroops / STROOPS_PER_XLM;
+
+  const xlmFormatted = totalXlm.toFixed(7);
+
+  let fiat: string | null = null;
+  if (xlmRate !== null && xlmRate > 0) {
+    const usdValue = totalXlm * xlmRate;
+    fiat = `≈ ${usdValue.toLocaleString('en-US', {
+      style: 'currency',
+      currency: 'USD',
+      minimumFractionDigits: 6,
+      maximumFractionDigits: 6,
+    })}`;
+  }
+
+  const capacityUsage = parseFloat(
+    (stats as unknown as Record<string, string>)['ledger_capacity_usage'] ?? '0',
+  );
+
+  return { stroops: totalStroops, xlm: xlmFormatted, fiat, capacityUsage };
+}
+
+/** Clears the fee cache so the next call forces a fresh fetch. */
+export function clearFeeCache(): void {
+  feeCache = null;
+}


### PR DESCRIPTION
## Summary

This PR implements four open issues on the `/send` flow.

---

### Issue #424 — Wallet connect integration on the send flow

- **Persistence**: ConnectStep now calls `loadPersistedWallet` on mount and restores the wallet from `localStorage` so the sender doesn't have to re-connect every time they navigate back through the flow.
- **Disconnect**: Added a "Disconnect wallet" link that calls `clearPersistedWallet` and clears the key in the parent form state.
- **Rejection handling**: Rejection errors (user declined, `User rejected`) are mapped to a clear human message distinct from "not installed" errors.
- **Unsupported-browser fallback**: `isBrowserExtensionSupported()` detects non-extension environments (Safari mobile, in-app webviews) and renders an amber informational banner instead of the connect button.

---

### Issue #425 — Expiration time selector for ephemeral accounts

- The ExpiryStep already had preset selection (24h / 7d / 30d / custom) and a sensible 7-day default.
- **Added**: A "Claim expires" row in the ConfirmStep summary table, showing the selected window (e.g. "7 days from now") clearly before the sender submits.
- SendForm now handles wallet disconnect (empty key) without advancing steps.

---

### Issue #426 — Fee estimation display before sending

- **New**: `frontend/lib/fee-estimation.ts` — fetches `/fee_stats` from Horizon, uses p50 of `max_fee` per operation × 2 ops.
- **ConfirmStep** now renders an "Estimated network fee" panel with the fee in XLM and USD (when the XLM/USD rate is available).
- A refresh button and a 30-second auto-refresh keep the estimate current while the user is on the confirm step.
- Shows a "Network is currently busy" warning when `ledger_capacity_usage > 0.8`.

---

### Issue #427 — Batch sending to multiple recipients

- **New**: `frontend/components/batch-send-form.tsx` — full batch send UI.
  - Manual row entry with add/remove controls (up to 100 rows).
  - CSV upload (columns: `name, email, amount, asset`).
  - Per-recipient validation before submission (name required, email optional, positive amount, supported asset).
  - Sequential processing with per-row processing / success / error indicators.
  - Batch summary: "N succeeded, M failed out of total".
  - "Retry failed" button re-queues only failed rows.
- **New**: `frontend/components/send-page-client.tsx` — client wrapper that adds a Single / Batch toggle above the existing `SendForm`.
- `/send` page updated to render `SendPageClient` instead of `SendForm` directly.

---

## Tests

- `connect-step.test.tsx` updated: mocks `loadPersistedWallet`, `persistWallet`, `clearPersistedWallet`; tests persistence restore, disconnect, rejection message, unsupported-browser fallback via `extensionSupportedOverride` prop.
- `lib/fee-estimation.test.ts` — new: tests XLM + fiat output, caching, error propagation, opCount, capacityUsage.
- `components/batch-send-form.test.tsx` — new: tests `validateRecipient`, `parseCsv`, wallet restore, add/remove rows, validation errors, batch success and error states.

**All 229 tests pass. Build: green.**

---

Closes #424
Closes #425
Closes #426
Closes #427