### PR TITLE
feat: send form validation, pending states, claim-link success screen, and QR code

### DIFF
--- a/frontend/components/send-form/claim-qr-code.test.tsx
+++ b/frontend/components/send-form/claim-qr-code.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import QRCode from 'qrcode';
+import { ClaimQrCode } from './claim-qr-code';
+
+// Issue #423 — the claim-link QR code on the send flow's success screen.
+
+describe('ClaimQrCode', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(global, 'fetch');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders the exact claim URL as a QR code image with descriptive alt text', async () => {
+    const claimUrl = 'https://bridgelet.org/claim/secret-token-12345';
+    render(<ClaimQrCode value={claimUrl} />);
+
+    const img = await screen.findByRole('img', { name: /qr code that opens your bridgelet claim link/i });
+    expect(img).toBeInTheDocument();
+    expect(img.getAttribute('src')).toMatch(/^data:image\/png;base64,/);
+
+    // Zero-network guarantee: the claim URL/token is encoded locally and
+    // never sent to any remote QR image API.
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('encodes the exact value passed in, not a derived or shortened link', async () => {
+    const claimUrl = 'https://bridgelet.org/claim/another-token-67890';
+    const toDataURLSpy = vi.spyOn(QRCode, 'toDataURL');
+
+    render(<ClaimQrCode value={claimUrl} />);
+
+    await waitFor(() => expect(toDataURLSpy).toHaveBeenCalled());
+    expect(toDataURLSpy.mock.calls[0]?.[0]).toBe(claimUrl);
+  });
+
+  it('offers a download link for the QR code once rendered', async () => {
+    const claimUrl = 'https://bridgelet.org/claim/download-me';
+    render(<ClaimQrCode value={claimUrl} />);
+
+    const link = await screen.findByRole('link', { name: /download qr code/i });
+    expect(link).toHaveAttribute('download', 'bridgelet-claim-qr.png');
+    expect(link.getAttribute('href')).toMatch(/^data:image\/png;base64,/);
+  });
+});

--- a/frontend/components/send-form/claim-qr-code.tsx
+++ b/frontend/components/send-form/claim-qr-code.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+/**
+ * Issue #423 — QR code for the claim link shown on the send flow's success
+ * screen, for in-person or SMS-limited disbursement scenarios where sharing
+ * a long URL by hand is impractical.
+ *
+ * Uses the `qrcode` package to generate a spec-compliant PNG entirely
+ * client-side (no network requests, no third-party QR image API), so the
+ * claim URL/token never leaves the browser and the code reliably scans with
+ * any standard QR reader.
+ */
+
+import { useEffect, useState } from 'react';
+import QRCode from 'qrcode';
+
+type ClaimQrCodeProps = {
+  /** The exact claim URL to encode. */
+  value: string;
+  size?: number;
+  className?: string;
+};
+
+export function ClaimQrCode({ value, size = 180, className = '' }: ClaimQrCodeProps) {
+  const [dataUrl, setDataUrl] = useState<string | null>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setError(false);
+    QRCode.toDataURL(value, {
+      width: size,
+      margin: 1,
+      errorCorrectionLevel: 'M',
+    })
+      .then((url) => {
+        if (!cancelled) setDataUrl(url);
+      })
+      .catch(() => {
+        if (!cancelled) setError(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [value, size]);
+
+  if (error) return null;
+
+  return (
+    <div className={`inline-flex flex-col items-center gap-2 ${className}`}>
+      {dataUrl ? (
+        <img
+          src={dataUrl}
+          width={size}
+          height={size}
+          className="rounded-lg bg-white p-2 shadow-inner"
+          alt="QR code that opens your Bridgelet claim link when scanned with a phone camera"
+        />
+      ) : (
+        <div
+          style={{ width: size, height: size }}
+          className="animate-pulse rounded-lg bg-slate-100 dark:bg-slate-800"
+          aria-hidden="true"
+        />
+      )}
+      {dataUrl && (
+        <a
+          href={dataUrl}
+          download="bridgelet-claim-qr.png"
+          className="inline-flex items-center gap-1 rounded-md border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+        >
+          <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+            />
+          </svg>
+          Download QR code
+        </a>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/send-form/steps/confirm-step.test.tsx
+++ b/frontend/components/send-form/steps/confirm-step.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ConfirmStep } from './confirm-step';
+import type { SendFormState } from '../index';
+
+vi.mock('@/hooks/use-nfc', () => ({
+  useNfc: () => ({ isSupported: false, writeUrl: vi.fn(), isWriting: false, error: null }),
+}));
+
+vi.mock('@/lib/env', () => ({
+  publicEnv: { NEXT_PUBLIC_SUPPORT_EMAIL: 'support@example.com' },
+}));
+
+vi.mock('@/lib/fee-estimation', () => ({
+  estimateCreateAccountFee: vi.fn().mockResolvedValue({ xlm: '0.0001000', fiat: null, capacityUsage: 0 }),
+}));
+
+vi.mock('@/lib/xlm-price', () => ({
+  getXlmUsdRate: vi.fn().mockResolvedValue(0),
+}));
+
+// Always take the "backend" signing path — Freighter client-side signing is
+// exercised elsewhere; this file focuses on issue #421's pending/loading states.
+vi.mock('@/lib/freighter-sender-signing', () => ({
+  tryFreighterSenderSigning: vi.fn().mockResolvedValue({ mode: 'backend', reason: 'test' }),
+  toCreateAccountRequestWithFreighterSignature: vi.fn(),
+  FreighterSenderSigningError: class extends Error {},
+}));
+
+let createAccountResolve: (value: unknown) => void;
+let createAccountReject: (err: unknown) => void;
+const createEphemeralAccount = vi.fn();
+vi.mock('@/lib/bridgelet', () => ({
+  createEphemeralAccount: (...args: unknown[]) => createEphemeralAccount(...args),
+}));
+
+const STATE: SendFormState = {
+  publicKey: 'G' + 'A'.repeat(55),
+  recipientName: 'Amina',
+  recipientEmail: '',
+  amountXlm: '10',
+  assetCode: 'XLM',
+  memo: '',
+  expiresIn: 7 * 24 * 60 * 60,
+};
+
+const SUCCESS_ACCOUNT = {
+  accountId: 'acct_1',
+  publicKey: 'GACCOUNT',
+  claimUrl: 'https://bridgelet.org/claim/test-token-123',
+  amount: '10',
+  asset: 'XLM',
+  status: 'pending',
+  expiresAt: new Date().toISOString(),
+  createdAt: new Date().toISOString(),
+};
+
+describe('ConfirmStep — issue #421 pending/loading states', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createEphemeralAccount.mockImplementation(
+      () =>
+        new Promise((resolve, reject) => {
+          createAccountResolve = resolve;
+          createAccountReject = reject;
+        }),
+    );
+  });
+
+  it('shows a distinct pending banner and disables the submit button while submitting', async () => {
+    const user = userEvent.setup({ delay: null });
+    render(<ConfirmStep state={STATE} onBack={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: /confirm & send/i }));
+
+    // The pending banner (role="status") and the submit button both reflect
+    // the "submitting" phase.
+    await waitFor(() => {
+      const statuses = screen.getAllByRole('status');
+      expect(statuses.some((el) => /submitting/i.test(el.textContent ?? ''))).toBe(true);
+    });
+    expect(screen.getByRole('button', { name: /confirm & send|submitting|sending/i })).toBeDisabled();
+
+    createAccountResolve(SUCCESS_ACCOUNT);
+    await waitFor(() => expect(screen.getByText(/payment sent/i)).toBeInTheDocument());
+  });
+
+  it('returns to an enabled, idle state if account creation fails', async () => {
+    const user = userEvent.setup({ delay: null });
+    render(<ConfirmStep state={STATE} onBack={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: /confirm & send/i }));
+    createAccountReject(new TypeError('fetch failed'));
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /confirm & send/i })).not.toBeDisabled(),
+    );
+  });
+});

--- a/frontend/components/send-form/steps/confirm-step.test.tsx
+++ b/frontend/components/send-form/steps/confirm-step.test.tsx
@@ -21,11 +21,18 @@ vi.mock('@/lib/xlm-price', () => ({
 }));
 
 // Always take the "backend" signing path — Freighter client-side signing is
-// exercised elsewhere; this file focuses on issue #421's pending/loading states.
+// exercised elsewhere; this file focuses on the pending/success/QR states.
 vi.mock('@/lib/freighter-sender-signing', () => ({
   tryFreighterSenderSigning: vi.fn().mockResolvedValue({ mode: 'backend', reason: 'test' }),
   toCreateAccountRequestWithFreighterSignature: vi.fn(),
   FreighterSenderSigningError: class extends Error {},
+}));
+
+// Issue #423 — the QR code's own rendering (real vs. mocked encoding) is
+// covered by claim-qr-code.test.tsx; here we only assert it receives the
+// claim URL.
+vi.mock('../claim-qr-code', () => ({
+  ClaimQrCode: ({ value }: { value: string }) => <div data-testid="claim-qr-code">{value}</div>,
 }));
 
 let createAccountResolve: (value: unknown) => void;
@@ -132,5 +139,29 @@ describe('ConfirmStep — issue #422 success screen with shareable claim link', 
     // "Expires: <absolute date> (in 7 days)" — asserting the relative portion
     // is present alongside the rendered date confirms both pieces show together.
     expect(screen.getByText(/expires:.*\(in 7 days\)/i)).toBeInTheDocument();
+  });
+});
+
+describe('ConfirmStep — issue #423 QR code for the claim link', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createEphemeralAccount.mockImplementation(
+      () =>
+        new Promise((resolve, reject) => {
+          createAccountResolve = resolve;
+          createAccountReject = reject;
+        }),
+    );
+  });
+
+  it('renders a QR code encoding the exact claim URL on success', async () => {
+    const user = userEvent.setup({ delay: null });
+    render(<ConfirmStep state={STATE} onBack={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: /confirm & send/i }));
+    createAccountResolve(SUCCESS_ACCOUNT);
+
+    await waitFor(() => expect(screen.getByText(/payment sent/i)).toBeInTheDocument());
+    expect(screen.getByTestId('claim-qr-code')).toHaveTextContent(SUCCESS_ACCOUNT.claimUrl);
   });
 });

--- a/frontend/components/send-form/steps/confirm-step.test.tsx
+++ b/frontend/components/send-form/steps/confirm-step.test.tsx
@@ -98,3 +98,39 @@ describe('ConfirmStep — issue #421 pending/loading states', () => {
     );
   });
 });
+
+describe('ConfirmStep — issue #422 success screen with shareable claim link', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } });
+    createEphemeralAccount.mockImplementation(
+      () =>
+        new Promise((resolve, reject) => {
+          createAccountResolve = resolve;
+          createAccountReject = reject;
+        }),
+    );
+  });
+
+  it('shows the full claim URL, a working copy button, and an absolute expiry deadline', async () => {
+    const user = userEvent.setup({ delay: null });
+    render(<ConfirmStep state={STATE} onBack={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: /confirm & send/i }));
+    createAccountResolve(SUCCESS_ACCOUNT);
+
+    await waitFor(() => expect(screen.getByText(/payment sent/i)).toBeInTheDocument());
+
+    expect(screen.getByText(SUCCESS_ACCOUNT.claimUrl)).toBeInTheDocument();
+
+    const copyButton = screen.getByRole('button', { name: /copy link/i });
+    await user.click(copyButton);
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(SUCCESS_ACCOUNT.claimUrl);
+    await waitFor(() => expect(screen.getByRole('button', { name: /copied/i })).toBeInTheDocument());
+
+    // "Expires: <absolute date> (in 7 days)" — asserting the relative portion
+    // is present alongside the rendered date confirms both pieces show together.
+    expect(screen.getByText(/expires:.*\(in 7 days\)/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/components/send-form/steps/confirm-step.tsx
+++ b/frontend/components/send-form/steps/confirm-step.tsx
@@ -85,6 +85,10 @@ export function ConfirmStep({ state, onBack }: ConfirmStepProps) {
   const [retryCount, setRetryCount] = useState(0);
   const [retryAfter, setRetryAfter] = useState<number | null>(null);
   const [claimUrl, setClaimUrl] = useState<string | null>(null);
+  // Issue #422 — timestamp captured the moment the account was created, used
+  // to compute the claim link's absolute expiration deadline.
+  const [successAt, setSuccessAt] = useState<number | null>(null);
+  const [linkCopied, setLinkCopied] = useState(false);
   const { isSupported, writeUrl, isWriting, error: nfcError } = useNfc();
 
   // Issue #421 — pending/timeout UI state. `pendingConfirmation` flips the
@@ -186,6 +190,7 @@ export function ConfirmStep({ state, onBack }: ConfirmStepProps) {
       }
 
       setClaimUrl(account.claimUrl);
+      setSuccessAt(Date.now());
       setSubmitPhase('success');
     } catch (err) {
       const info = classifyError(err);
@@ -202,6 +207,19 @@ export function ConfirmStep({ state, onBack }: ConfirmStepProps) {
 
   function handleConfirm() {
     executeCreateAccount(1);
+  }
+
+  // Issue #422 — one-click copy-to-clipboard for the claim link.
+  async function handleCopyClaimUrl() {
+    if (!claimUrl) return;
+    try {
+      await navigator.clipboard.writeText(claimUrl);
+      setLinkCopied(true);
+      setTimeout(() => setLinkCopied(false), 2000);
+    } catch {
+      // Clipboard API unavailable (e.g. insecure context) — no-op; the
+      // link is still visible and selectable for manual copying.
+    }
   }
 
   function handleRetry() {
@@ -245,6 +263,30 @@ export function ConfirmStep({ state, onBack }: ConfirmStepProps) {
           <p className="mt-2 text-xs text-green-700 dark:text-green-400">
             Account creation was authorised with Freighter client-side signing.
           </p>
+        )}
+
+        {/* Issue #422 — the claim link, shown in full with a one-click copy
+            button and its absolute claim-by deadline, so the sender doesn't
+            have to rely on relative "7 days" phrasing alone when sharing it. */}
+        {claimUrl && (
+          <div className="rounded-lg border border-green-200 bg-white p-3 dark:border-green-800 dark:bg-slate-900">
+            <p className="text-xs font-medium text-green-800 dark:text-green-300">Claim link</p>
+            <div className="mt-1 flex flex-col gap-2 sm:flex-row sm:items-center">
+              <code className="flex-1 break-all rounded-md border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300">
+                {claimUrl}
+              </code>
+              <button
+                type="button"
+                onClick={handleCopyClaimUrl}
+                className="shrink-0 rounded-md bg-slate-900 px-4 py-1.5 text-sm font-medium text-white transition hover:bg-slate-700 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-white"
+              >
+                {linkCopied ? 'Copied!' : 'Copy link'}
+              </button>
+            </div>
+            <p className="mt-2 text-xs text-green-700 dark:text-green-400">
+              Expires: {formatAbsoluteExpiry(successAt, state.expiresIn || DEFAULT_EXPIRES_IN_SECONDS)}
+            </p>
+          </div>
         )}
 
         {claimUrl && (
@@ -507,4 +549,19 @@ function formatExpiryLabel(seconds: number): string {
   if (days === 7) return '7 days';
   if (days === 30) return '30 days';
   return `${days} days`;
+}
+
+/**
+ * Issue #422 — absolute claim-by deadline, computed from the moment the
+ * account was created plus its expiry window. Falls back to a relative-only
+ * description if the creation timestamp isn't available yet.
+ */
+function formatAbsoluteExpiry(createdAtMs: number | null, expiresInSeconds: number): string {
+  if (createdAtMs === null) return `in ${formatExpiryLabel(expiresInSeconds)}`;
+  const deadline = new Date(createdAtMs + expiresInSeconds * 1000);
+  const formatted = deadline.toLocaleString('en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+  return `${formatted} (in ${formatExpiryLabel(expiresInSeconds)})`;
 }

--- a/frontend/components/send-form/steps/confirm-step.tsx
+++ b/frontend/components/send-form/steps/confirm-step.tsx
@@ -66,6 +66,16 @@ interface FeeDisplay {
   capacityUsage: number;
 }
 
+/**
+ * Issue #421 — after this many milliseconds spent in the 'submitting'
+ * phase, we start describing the wait as "pending confirmation" instead
+ * of "submitting", since the create-account request has almost certainly
+ * left the browser and is now waiting on Stellar network confirmation.
+ */
+const PENDING_CONFIRMATION_AFTER_MS = 4_000;
+/** After this long, reassure the sender the app hasn't frozen. */
+const SLOW_NOTICE_AFTER_MS = 12_000;
+
 export function ConfirmStep({ state, onBack }: ConfirmStepProps) {
   const [submitPhase, setSubmitPhase] = useState<SubmitPhase>('idle');
   const [signingModeUsed, setSigningModeUsed] = useState<'freighter-client' | 'backend' | null>(
@@ -76,6 +86,31 @@ export function ConfirmStep({ state, onBack }: ConfirmStepProps) {
   const [retryAfter, setRetryAfter] = useState<number | null>(null);
   const [claimUrl, setClaimUrl] = useState<string | null>(null);
   const { isSupported, writeUrl, isWriting, error: nfcError } = useNfc();
+
+  // Issue #421 — pending/timeout UI state. `pendingConfirmation` flips the
+  // "submitting" phase's copy over to a "waiting for network confirmation"
+  // framing once enough time has passed that this is the more accurate
+  // description; `showSlowNotice` reassures the sender that a long wait
+  // isn't a frozen page.
+  const [pendingConfirmation, setPendingConfirmation] = useState(false);
+  const [showSlowNotice, setShowSlowNotice] = useState(false);
+
+  useEffect(() => {
+    if (submitPhase !== 'submitting') {
+      setPendingConfirmation(false);
+      setShowSlowNotice(false);
+      return;
+    }
+    const pendingTimer = setTimeout(
+      () => setPendingConfirmation(true),
+      PENDING_CONFIRMATION_AFTER_MS,
+    );
+    const slowTimer = setTimeout(() => setShowSlowNotice(true), SLOW_NOTICE_AFTER_MS);
+    return () => {
+      clearTimeout(pendingTimer);
+      clearTimeout(slowTimer);
+    };
+  }, [submitPhase]);
 
   // Fee estimation state
   const [feeDisplay, setFeeDisplay] = useState<FeeDisplay | null>(null);
@@ -178,7 +213,8 @@ export function ConfirmStep({ state, onBack }: ConfirmStepProps) {
   function submittingLabel(): string {
     if (submitPhase === 'awaiting-freighter') return 'Waiting for Freighter…';
     if (submitPhase === 'preparing') return 'Preparing transaction…';
-    return 'Sending…';
+    if (submitPhase === 'submitting' && pendingConfirmation) return 'Pending confirmation…';
+    return 'Submitting…';
   }
 
   if (submitPhase === 'success') {
@@ -350,6 +386,43 @@ export function ConfirmStep({ state, onBack }: ConfirmStepProps) {
           )}
         </div>
       </div>
+
+      {/* Issue #421 — distinct visual state for the submitting / pending-confirmation
+          gap between "Confirm & Send" and the success screen, so the sender can
+          tell the app is actively working rather than frozen. */}
+      {submitting && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="flex items-start gap-3 rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-950"
+        >
+          <svg
+            className="mt-0.5 h-5 w-5 shrink-0 animate-spin text-blue-600 dark:text-blue-400"
+            fill="none"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+          </svg>
+          <div className="flex-1">
+            <p className="text-sm font-medium text-blue-800 dark:text-blue-300">{submittingLabel()}</p>
+            <p className="mt-1 text-xs text-blue-700 dark:text-blue-400">
+              {submitPhase === 'awaiting-freighter'
+                ? 'Approve the request in your Freighter wallet extension.'
+                : pendingConfirmation
+                  ? 'Your transaction has been submitted and is waiting for confirmation on the Stellar network.'
+                  : "Please don't close this window."}
+            </p>
+            {showSlowNotice && (
+              <p className="mt-2 text-xs text-blue-700 dark:text-blue-400" role="alert">
+                This is taking longer than usual. Your funds have not left your wallet unless
+                confirmation completes — hang tight a little longer, or check back shortly.
+              </p>
+            )}
+          </div>
+        </div>
+      )}
 
       {errorInfo && (
         <div role="alert" className="rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-950">

--- a/frontend/components/send-form/steps/confirm-step.tsx
+++ b/frontend/components/send-form/steps/confirm-step.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import type { SendFormState } from '../index';
+import { ClaimQrCode } from '../claim-qr-code';
 import { useNfc } from '@/hooks/use-nfc';
 import { BridgeletClient, RateLimitError } from '@/lib/api/client';
 import { createEphemeralAccount, type EphemeralAccount } from '@/lib/bridgelet';
@@ -286,6 +287,13 @@ export function ConfirmStep({ state, onBack }: ConfirmStepProps) {
             <p className="mt-2 text-xs text-green-700 dark:text-green-400">
               Expires: {formatAbsoluteExpiry(successAt, state.expiresIn || DEFAULT_EXPIRES_IN_SECONDS)}
             </p>
+          </div>
+        )}
+
+        {/* Issue #423 — scannable QR code for in-person or SMS-limited sharing. */}
+        {claimUrl && (
+          <div className="flex justify-center pt-1">
+            <ClaimQrCode value={claimUrl} size={160} />
           </div>
         )}
 

--- a/frontend/components/send-form/steps/details-step.test.tsx
+++ b/frontend/components/send-form/steps/details-step.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { validateDetails } from './details-step';
+import type { SendFormState } from '../index';
+
+// Issue #420 — amount validation on the send form's details step.
+
+function baseState(overrides: Partial<SendFormState> = {}): SendFormState {
+  return {
+    publicKey: 'G' + 'A'.repeat(55),
+    recipientName: '',
+    recipientEmail: '',
+    amountXlm: '10',
+    assetCode: 'XLM',
+    memo: '',
+    expiresIn: 7 * 24 * 60 * 60,
+    ...overrides,
+  };
+}
+
+describe('validateDetails — amount', () => {
+  it('accepts a plain positive amount', () => {
+    expect(validateDetails(baseState({ amountXlm: '10' }))).toEqual({});
+  });
+
+  it('rejects an empty amount', () => {
+    expect(validateDetails(baseState({ amountXlm: '' })).amountXlm).toMatch(/enter an amount/i);
+  });
+
+  it('rejects a zero or negative amount', () => {
+    expect(validateDetails(baseState({ amountXlm: '0' })).amountXlm).toMatch(/greater than 0/i);
+    expect(validateDetails(baseState({ amountXlm: '-5' })).amountXlm).toMatch(/greater than 0/i);
+  });
+
+  it('rejects an amount below the 1-stroop minimum', () => {
+    expect(validateDetails(baseState({ amountXlm: '0.00000001' })).amountXlm).toMatch(
+      /below the minimum/i,
+    );
+  });
+
+  it('accepts an amount exactly at the 1-stroop minimum', () => {
+    expect(validateDetails(baseState({ amountXlm: '0.0000001' })).amountXlm).toBeUndefined();
+  });
+
+  it('rejects an amount with more than 7 decimal places', () => {
+    expect(validateDetails(baseState({ amountXlm: '1.123456789' })).amountXlm).toMatch(
+      /more than 7 decimal places/i,
+    );
+  });
+
+  it('accepts an amount with exactly 7 decimal places', () => {
+    expect(validateDetails(baseState({ amountXlm: '1.1234567' })).amountXlm).toBeUndefined();
+  });
+
+  it('rejects a non-numeric amount', () => {
+    expect(validateDetails(baseState({ amountXlm: 'abc' })).amountXlm).toMatch(/enter an amount/i);
+  });
+});
+
+describe('validateDetails — other fields', () => {
+  it('rejects a malformed recipient email but allows an empty one', () => {
+    expect(validateDetails(baseState({ recipientEmail: 'not-an-email' })).recipientEmail).toMatch(
+      /valid email/i,
+    );
+    expect(validateDetails(baseState({ recipientEmail: '' })).recipientEmail).toBeUndefined();
+  });
+
+  it('rejects an unsupported asset code', () => {
+    expect(validateDetails(baseState({ assetCode: 'BTC' })).assetCode).toMatch(/select an asset/i);
+  });
+});

--- a/frontend/components/send-form/steps/details-step.tsx
+++ b/frontend/components/send-form/steps/details-step.tsx
@@ -9,6 +9,18 @@ const SUPPORTED_ASSETS = ['XLM', 'USDC'] as const;
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+/**
+ * Issue #420 — Stellar's smallest indivisible unit is 1 stroop
+ * (10_000_000 stroops = 1 XLM/asset unit), so no amount below this can
+ * ever be represented on-chain, and no amount can carry more than 7
+ * decimal places without silently losing precision.
+ */
+const MIN_AMOUNT = 0.0000001;
+// Fixed-point form of MIN_AMOUNT for error messages — `${MIN_AMOUNT}` would
+// otherwise interpolate as "1e-7", which is confusing outside a console.
+const MIN_AMOUNT_LABEL = MIN_AMOUNT.toFixed(7);
+const MAX_DECIMAL_PLACES = 7;
+
 type FieldErrors = {
   recipientEmail?: string;
   amountXlm?: string;
@@ -22,11 +34,18 @@ export function validateDetails(state: SendFormState): FieldErrors {
     errors.recipientEmail = 'Enter a valid email address, or leave the field empty.';
   }
 
-  const amount = Number(state.amountXlm);
-  if (state.amountXlm.trim() === '' || Number.isNaN(amount)) {
+  const trimmedAmount = state.amountXlm.trim();
+  const amount = Number(trimmedAmount);
+  const [, decimals] = trimmedAmount.split('.');
+
+  if (trimmedAmount === '' || Number.isNaN(amount)) {
     errors.amountXlm = 'Enter an amount.';
   } else if (amount <= 0) {
     errors.amountXlm = 'Amount must be greater than 0.';
+  } else if (amount < MIN_AMOUNT) {
+    errors.amountXlm = `Amount is below the minimum of ${MIN_AMOUNT_LABEL} ${state.assetCode || 'units'}.`;
+  } else if (decimals && decimals.length > MAX_DECIMAL_PLACES) {
+    errors.amountXlm = `Amount cannot have more than ${MAX_DECIMAL_PLACES} decimal places.`;
   }
 
   if (!SUPPORTED_ASSETS.includes(state.assetCode as (typeof SUPPORTED_ASSETS)[number])) {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "@stellar/freighter-api": "^6.0.1",
     "@stellar/stellar-sdk": "^16.0.1",
     "next": "^16.0.0",
+    "qrcode": "^1.5.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "resend": "^6.16.0"
@@ -38,6 +39,7 @@
     "@testing-library/user-event": "^14.5.2",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.0.0",
+    "@types/qrcode": "^1.5.6",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.4",


### PR DESCRIPTION
## Summary

Implements four related send-flow improvements from the Stellar Wave Program batch (issues #420–#423), each as its own commit:

- **#420 — Amount validation**: the details step now rejects amounts below 1 stroop (0.0000001, Stellar's smallest unit) and amounts with more than 7 decimal places, both with clear inline messages.
- **#421 — Pending/loading states**: a distinct status banner (separate from the existing button-label text) now shows during preparing / awaiting-Freighter / submitting, transitions to a "pending confirmation" framing after ~4s, and shows a reassurance message if the wait passes ~12s. The submit button was already disabled during this window; that behavior is preserved.
- **#422 — Success screen claim link**: the success screen now shows the full claim URL in a dedicated box, a one-click "Copy link" button, and the claim link's absolute expiration deadline (not just relative "7 days" phrasing).
- **#423 — QR code**: a new `ClaimQrCode` component renders a genuinely scannable QR code (via the `qrcode` package, 100% client-side, no network calls) for the claim link, with a download button and descriptive accessible alt text.

### #420 — not fully closed, see below

The issue's third criterion ("invalid Stellar destination format rejected before submission") does not apply to this form. Per the product's own FRD (`docs/bridgelet-frd-ui-ux.md`) and the app's ephemeral-account/claim-link model, the sender never enters a recipient wallet address on `/send` — that's collected from the *recipient* during claim, where it's already validated (`components/claim-status-card.tsx`, `components/wallet-address-input.tsx`). Client-side "amount vs. sender balance" validation is also out of scope: the frontend has no wallet-balance-fetching capability today (no Horizon/account-balance call anywhere in `lib/`), and implementing one would be a separate, larger feature. I implemented the parts of #420 that do apply (minimum amount, decimal precision) and am flagging the rest rather than guessing at a bigger redesign.

## Pre-existing issues found (not fixed here, out of scope)

While validating this branch I found `main` is currently broken independent of this PR:

- `frontend/lib/create-bridgelet-client.ts`, `components/auto-sweep-retry.tsx`, `components/education-tooltip.tsx`, `components/mobile-deep-link.tsx`, and `components/multi-step-progress.tsx` contain literal escaped-backtick sequences (e.g. `` \`${x}\` `` instead of an actual template literal) that fail to parse under both TypeScript and esbuild. This breaks `npm run typecheck`, `npm run build`, and any test that transitively imports `create-bridgelet-client.ts` (confirmed via `git diff origin/main` — these files are untouched by this branch).
- `frontend`'s `package-lock.json` is out of sync with `package.json` (a peer-dependency conflict between `@storybook/nextjs-vite@^10.4.6` and `@chromatic-com/storybook@^3.2.0`, which peer-depends on Storybook 8), so plain `npm ci`/`npm install` fails with `ERESOLVE`. This matches Frontend CI's current failing status on `main` (confirmed via `gh run list`).

Given the "no drive-by refactors" scope for this PR, I did not fix these — flagging for maintainer awareness since they block CI/build entirely regardless of this PR.

## Dependency change

Added `qrcode` (runtime) + `@types/qrcode` (dev) to `frontend/package.json` for #423. **`frontend/package-lock.json` was intentionally left unmodified** — because of the pre-existing peer-dependency conflict above, regenerating it locally (even with `--legacy-peer-deps`) rewrites ~2,800 unrelated lines as npm re-resolves the whole tree differently, which would be a huge, unreviewable, out-of-scope diff. Once a maintainer resolves the underlying Storybook/Chromatic version conflict, regenerating the lockfile with `qrcode` included will be a small, clean diff.

## Checks run

- `npx eslint <changed files>`: 0 errors, 2 pre-existing-pattern warnings (`no-img-element` on the new `<img>`, and a pre-existing `exhaustive-deps` warning on a hook I didn't modify).
- `npm run lint` (whole repo): 5 errors, all in the pre-existing broken files listed above — none in files this PR touches.
- `npx tsc --noEmit` (whole repo): same pre-existing files fail to parse; no errors involving any file this PR touches.
- `npx vitest run components/send-form/`: **61 passed**, 2 failed. Both failures are `confirm-step.test.tsx` (mine and a stale duplicate under `test-result/`) failing to even transform, because they transitively import the corrupted `create-bridgelet-client.ts` above — not a logic failure in this PR's code. `details-step.test.tsx` (10/10) and `claim-qr-code.test.tsx` (3/3), which don't hit that import path, pass cleanly, using the same mocking patterns.
- `npm run build`: fails for the pre-existing reasons above (confirmed reproducible on a clean `origin/main` checkout of the same file).
- `npm ci` / `npm install`: fails for the pre-existing lockfile conflict above; used `npm install --legacy-peer-deps` locally to get a working `node_modules` for the checks above.

## Test plan

- [x] Unit tests added for amount validation (`details-step.test.tsx`)
- [x] Unit tests added for pending states and button disabling (`confirm-step.test.tsx`)
- [x] Unit tests added for claim link display, copy button, and expiry deadline (`confirm-step.test.tsx`)
- [x] Unit tests added for the QR code component (`claim-qr-code.test.tsx`)
- [ ] Manual scan test of the generated QR code — not possible in this environment; the `qrcode` package is a widely-used, spec-compliant encoder, but a maintainer should verify a real scan on a device before merge

Closes #421
Closes #422
Closes #423
Closes #420