### PR TITLE
feat(claim): claim flow UI improvements (#432-#435)

### DIFF
--- a/frontend/app/claim/[token]/claim-page-client.tsx
+++ b/frontend/app/claim/[token]/claim-page-client.tsx
@@ -3,8 +3,8 @@
 import { useEffect, useState } from 'react';
 import { ClaimStatusCard } from '@/components/claim-status-card';
 import { AccountStatus } from '@/lib/api/types';
-import { BridgeletClient, BridgeletApiError } from '@/lib/api/client';
-import { ClaimView, loadClaimView, toStroops } from '@/lib/claim-view';
+import { BridgeletClient } from '@/lib/api/client';
+import { ClaimView, loadClaimView, markTokenClaimed } from '@/lib/claim-view';
 
 interface ClaimPageClientProps {
   token: string;
@@ -37,10 +37,17 @@ export function ClaimPageClient({ token, supportEmail, initialView }: ClaimPageC
     if (!result.success) {
       throw new Error(result.error ?? 'Claim could not be completed. Please try again.');
     }
+    // #435: record this session as the one that claimed the token
+    markTokenClaimed(token);
     setView((prev) => ({
       ...(prev ?? { status: AccountStatus.CLAIMED }),
       status: result.isPartial ? AccountStatus.PARTIAL_SWEEP : AccountStatus.CLAIMED,
       sweepNote: result.message,
+      // #435: we just claimed it in this session
+      claimedByMe: true,
+      // #433: destination and amount for success state
+      sweepDestination: destinationAddress,
+      sweepAmountStroops: prev?.amountStroops,
     }));
   }
 
@@ -75,6 +82,9 @@ export function ClaimPageClient({ token, supportEmail, initialView }: ClaimPageC
       sweepNote={view.sweepNote}
       supportEmail={supportEmail}
       onClaim={handleClaim}
+      claimedByMe={view.claimedByMe}
+      sweepDestination={view.sweepDestination}
+      sweepAmountStroops={view.sweepAmountStroops}
     />
   );
 }

--- a/frontend/components/claim-status-card.tsx
+++ b/frontend/components/claim-status-card.tsx
@@ -4,7 +4,892 @@ import { useState } from 'react';
 import { RateLimitBanner } from '@/components/rate-limit-banner';
 import { RateLimitError } from '@/lib/api/client';
 import { ChainSelector } from '@/components/chain-selector';
+import { WalletConnect } from '@/components/wallet-connect';
 import { AccountStatus } from '@/lib/api/types';
+
+/**
+ * ClaimStatus now mirrors the backend's real AccountStatus enum (Issue 5)
+ * instead of the old three-value `'available' | 'claimed' | 'expired'`
+ * model, which had no way to represent INITIALIZING, PENDING_PAYMENT,
+ * CLAIMING, PARTIAL_SWEEP, or FAILED accounts.
+ */
+export type ClaimStatus = AccountStatus;
+
+export interface ClaimStatusCardProps {
+  /** Current lifecycle status of the account, as returned by the backend. */
+  status: ClaimStatus;
+  /** Payment amount in stroops (1 XLM = 10_000_000). Required for `pending_claim`. */
+  amountStroops?: string;
+  /** ISO 4217 asset code, e.g. "XLM" or "USDC". */
+  assetCode?: string;
+  /** ISO 8601 timestamp when the token expires / expired. */
+  expiresAt?: string;
+  /** Optional sender memo. */
+  memo?: string;
+  /** Called when the recipient submits a destination address to claim to. Also used to retry a PARTIAL_SWEEP. */
+  onClaim?: (destinationAddress: string) => void | Promise<void>;
+  /** Developer-facing note from the API (e.g. sweep_status stub message). */
+  sweepNote?: string;
+  /** Support contact email shown in the expired/failed states. */
+  supportEmail?: string;
+  /**
+   * #435: True when this browser session was the one that claimed the token.
+   * Determines whether to show "you already claimed this" vs "claimed by someone else".
+   */
+  claimedByMe?: boolean;
+  /**
+   * #433: Destination wallet address reported after a successful sweep,
+   * shown in the final success confirmation state.
+   */
+  sweepDestination?: string;
+  /**
+   * #433: Amount in stroops actually swept (may differ from amountStroops after fees).
+   */
+  sweepAmountStroops?: string;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function stroopsToDisplay(stroops: string, assetCode = 'XLM'): string {
+  const num = parseFloat(stroops);
+  if (Number.isNaN(num)) return `— ${assetCode}`;
+  const xlm = num / 10_000_000;
+  return `${xlm.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 7 })} ${assetCode}`;
+}
+
+function formatExpiry(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString('en-US', {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function shortenAddress(address: string): string {
+  if (address.length <= 16) return address;
+  return `${address.slice(0, 6)}…${address.slice(-6)}`;
+}
+
+// ─── Display metadata for every real backend status ───────────────────────────
+
+const HEADERS: Record<ClaimStatus, string> = {
+  [AccountStatus.INITIALIZING]: 'Setting up your payment',
+  [AccountStatus.PENDING_PAYMENT]: 'Waiting for payment',
+  [AccountStatus.PENDING_CLAIM]: 'You have a payment waiting',
+  [AccountStatus.CLAIMING]: 'Funds are moving to your wallet',
+  [AccountStatus.PARTIAL_SWEEP]: 'Finishing up your claim',
+  [AccountStatus.CLAIMED]: 'Payment claimed',
+  [AccountStatus.EXPIRED]: 'Payment link expired',
+  [AccountStatus.FAILED]: 'Something went wrong',
+};
+
+const BORDER_COLORS: Record<ClaimStatus, string> = {
+  [AccountStatus.INITIALIZING]: 'border-slate-200 dark:border-slate-700',
+  [AccountStatus.PENDING_PAYMENT]: 'border-amber-200 dark:border-amber-800',
+  [AccountStatus.PENDING_CLAIM]: 'border-green-200 dark:border-green-800',
+  [AccountStatus.CLAIMING]: 'border-blue-200 dark:border-blue-800',
+  [AccountStatus.PARTIAL_SWEEP]: 'border-blue-200 dark:border-blue-800',
+  [AccountStatus.CLAIMED]: 'border-blue-200 dark:border-blue-800',
+  [AccountStatus.EXPIRED]: 'border-amber-200 dark:border-amber-700',
+  [AccountStatus.FAILED]: 'border-red-200 dark:border-red-800',
+};
+
+const BADGE_STYLES: Record<ClaimStatus, { dot: string; text: string; label: string }> = {
+  [AccountStatus.INITIALIZING]: {
+    dot: 'bg-slate-400',
+    text: 'text-slate-600 dark:text-slate-400',
+    label: 'Setting up',
+  },
+  [AccountStatus.PENDING_PAYMENT]: {
+    dot: 'bg-amber-500',
+    text: 'text-amber-700 dark:text-amber-400',
+    label: 'Awaiting payment',
+  },
+  [AccountStatus.PENDING_CLAIM]: {
+    dot: 'bg-green-500',
+    text: 'text-green-700 dark:text-green-400',
+    label: 'Available',
+  },
+  [AccountStatus.CLAIMING]: {
+    dot: 'bg-blue-500',
+    text: 'text-blue-700 dark:text-blue-400',
+    label: 'Sending',
+  },
+  [AccountStatus.PARTIAL_SWEEP]: {
+    dot: 'bg-blue-500',
+    text: 'text-blue-700 dark:text-blue-400',
+    label: 'Processing',
+  },
+  [AccountStatus.CLAIMED]: {
+    dot: 'bg-green-500',
+    text: 'text-green-700 dark:text-green-400',
+    label: 'Claimed',
+  },
+  [AccountStatus.EXPIRED]: {
+    dot: 'bg-amber-500',
+    text: 'text-amber-700 dark:text-amber-400',
+    label: 'Expired',
+  },
+  [AccountStatus.FAILED]: {
+    dot: 'bg-red-500',
+    text: 'text-red-700 dark:text-red-400',
+    label: 'Failed',
+  },
+};
+
+function StatusBadge({ status }: { status: ClaimStatus }) {
+  const { dot, text, label } = BADGE_STYLES[status];
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wider ${text}`}
+    >
+      <span className={`inline-block h-2 w-2 rounded-full ${dot}`} aria-hidden="true" />
+      {label}
+    </span>
+  );
+}
+
+// ─── State panels ─────────────────────────────────────────────────────────────
+
+/**
+ * #432: AvailablePanel offers both paths side-by-side:
+ *   1. Connect an existing Freighter wallet — prefills the address and shows a
+ *      confirmation step before the sweep fires.
+ *   2. Enter an address manually (original "no-wallet" path).
+ *
+ * #433: After a successful claim, shows a distinct sweep-in-progress state
+ * and then a final success card with the destination and amount.
+ */
+function AvailablePanel({
+  amountStroops,
+  assetCode,
+  expiresAt,
+  memo,
+  onClaim,
+  sweepNote,
+}: Pick<
+  ClaimStatusCardProps,
+  'amountStroops' | 'assetCode' | 'expiresAt' | 'memo' | 'onClaim' | 'sweepNote'
+>) {
+  // Wallet-connect state
+  const [connectedAddress, setConnectedAddress] = useState<string | null>(null);
+  const [walletConnectError, setWalletConnectError] = useState<string | null>(null);
+
+  // Manual-entry state
+  const [destinationAddress, setDestinationAddress] = useState('');
+
+  // Confirmation-before-sweep
+  const [pendingAddress, setPendingAddress] = useState<string | null>(null);
+
+  // Sweep execution state
+  const [claiming, setClaiming] = useState(false);
+  const [rateLimit, setRateLimit] = useState<number | null | undefined>(undefined);
+  const [claimError, setClaimError] = useState<string | null>(null);
+
+  // #433 post-claim states
+  const [sweepInProgress, setSweepInProgress] = useState(false);
+  const [sweepDone, setSweepDone] = useState<{ address: string; amount?: string } | null>(null);
+
+  const manualIsValid = /^G[A-Z2-7]{55}$/.test(destinationAddress);
+
+  // Called when user clicks "Use this address" from either wallet-connect or manual entry.
+  function requestConfirm(address: string) {
+    setPendingAddress(address);
+    setClaimError(null);
+    setRateLimit(undefined);
+  }
+
+  function cancelConfirm() {
+    setPendingAddress(null);
+  }
+
+  async function executeClaim(address: string) {
+    setClaiming(true);
+    setClaimError(null);
+    setRateLimit(undefined);
+    try {
+      await onClaim?.(address);
+      // #433: show "funds moving" state before final success
+      setSweepInProgress(true);
+      setPendingAddress(null);
+      // Give users brief "funds are moving" feedback, then show success.
+      // In production the parent component will poll and update status, but
+      // we optimistically show the final state after a short pause.
+      setTimeout(() => {
+        setSweepInProgress(false);
+        setSweepDone({ address, amount: amountStroops });
+      }, 2000);
+    } catch (err) {
+      if (err instanceof RateLimitError) {
+        setRateLimit(err.retryAfter);
+      } else {
+        setClaimError(
+          err instanceof Error ? err.message : 'Something went wrong. Please try again.',
+        );
+      }
+      setPendingAddress(null);
+    } finally {
+      setClaiming(false);
+    }
+  }
+
+  // #433: Sweep-in-progress state — distinct from claim initiation.
+  if (sweepInProgress) {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="flex items-center gap-3 rounded-lg border border-blue-200 bg-blue-50 px-4 py-4 dark:border-blue-800 dark:bg-blue-950"
+      >
+        <span
+          className="h-5 w-5 shrink-0 animate-spin rounded-full border-2 border-blue-500 border-t-transparent dark:border-blue-400"
+          aria-hidden="true"
+        />
+        <div>
+          <p className="text-sm font-semibold text-blue-800 dark:text-blue-200">
+            Funds are moving to your wallet
+          </p>
+          <p className="text-xs text-blue-600 mt-0.5 dark:text-blue-400">
+            Your transfer is being processed on the Stellar network. This usually takes a few
+            seconds.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // #433: Final success state — shows destination and amount.
+  if (sweepDone) {
+    return (
+      <div role="status" aria-live="polite" className="space-y-3">
+        <div className="flex items-start gap-3 rounded-lg border border-green-200 bg-green-50 px-4 py-4 dark:border-green-800 dark:bg-green-950">
+          <svg
+            aria-hidden="true"
+            className="mt-0.5 h-5 w-5 shrink-0 text-green-600 dark:text-green-400"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
+          </svg>
+          <div className="min-w-0">
+            <p className="text-sm font-semibold text-green-800 dark:text-green-200">
+              Payment sent successfully!
+            </p>
+            {sweepDone.amount && (
+              <p className="text-sm text-green-700 mt-0.5 dark:text-green-300">
+                {stroopsToDisplay(sweepDone.amount, assetCode)} has been sent to your wallet.
+              </p>
+            )}
+            <p className="mt-1 break-all font-mono text-xs text-green-600 dark:text-green-400">
+              {sweepDone.address}
+            </p>
+          </div>
+        </div>
+        {sweepNote && (
+          <p className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-2 dark:text-amber-300 dark:bg-amber-950 dark:border-amber-800">
+            🛠 Dev note: {sweepNote}
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  // #432: Confirmation step — shown before executing the sweep.
+  if (pendingAddress) {
+    return (
+      <div role="dialog" aria-label="Confirm destination address" className="space-y-4">
+        <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 dark:border-slate-700 dark:bg-slate-800">
+          <p className="text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">
+            Sending to
+          </p>
+          <p className="break-all font-mono text-sm text-slate-900 dark:text-slate-100">
+            {pendingAddress}
+          </p>
+          {amountStroops && (
+            <p className="mt-2 text-sm font-semibold text-slate-700 dark:text-slate-300">
+              Amount:{' '}
+              <span className="text-slate-900 dark:text-slate-100">
+                {stroopsToDisplay(amountStroops, assetCode)}
+              </span>
+            </p>
+          )}
+          <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+            Double-check this address — Stellar transfers cannot be reversed.
+          </p>
+        </div>
+
+        {rateLimit !== undefined && <RateLimitBanner retryAfter={rateLimit} />}
+        {claimError && (
+          <p
+            role="alert"
+            className="text-sm text-red-700 bg-red-50 border border-red-200 rounded px-3 py-2 dark:text-red-300 dark:bg-red-950 dark:border-red-800"
+          >
+            {claimError}
+          </p>
+        )}
+
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => executeClaim(pendingAddress)}
+            disabled={claiming}
+            className="flex-1 rounded-lg bg-green-600 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-green-700 disabled:opacity-60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-600 dark:bg-green-700 dark:hover:bg-green-600"
+          >
+            {claiming ? 'Sending…' : 'Confirm & send'}
+          </button>
+          <button
+            type="button"
+            onClick={cancelConfirm}
+            disabled={claiming}
+            className="rounded-lg border border-slate-300 px-4 py-2.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50 disabled:opacity-60 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-800"
+          >
+            Back
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      {/* Payment details */}
+      <dl className="space-y-2 text-sm">
+        <div className="flex justify-between">
+          <dt className="font-medium text-slate-700 dark:text-slate-300">Amount</dt>
+          <dd className="font-semibold text-slate-900 dark:text-slate-100">
+            {amountStroops ? (
+              stroopsToDisplay(amountStroops, assetCode)
+            ) : (
+              <span className="text-slate-400 dark:text-slate-500">—</span>
+            )}
+          </dd>
+        </div>
+        {expiresAt && (
+          <div className="flex justify-between">
+            <dt className="font-medium text-slate-700 dark:text-slate-300">Expires</dt>
+            <dd className="text-slate-600 dark:text-slate-400">{formatExpiry(expiresAt)}</dd>
+          </div>
+        )}
+        {memo && (
+          <div className="flex justify-between">
+            <dt className="font-medium text-slate-700 dark:text-slate-300">Memo</dt>
+            <dd className="text-slate-600 dark:text-slate-400">{memo}</dd>
+          </div>
+        )}
+      </dl>
+
+      <hr className="border-slate-100 dark:border-slate-800" />
+
+      {/* #432: Existing-wallet connect path */}
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400 mb-2">
+          Already have a Stellar wallet?
+        </p>
+        {connectedAddress ? (
+          <div className="space-y-2">
+            <div className="flex items-center justify-between gap-2 rounded-lg border border-green-200 bg-green-50 px-3 py-2 dark:border-green-800 dark:bg-green-950">
+              <div className="min-w-0">
+                <p className="text-xs font-medium text-green-800 dark:text-green-300">
+                  Freighter connected
+                </p>
+                <p className="break-all font-mono text-xs text-green-700 dark:text-green-400">
+                  {connectedAddress}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => {
+                  setConnectedAddress(null);
+                  setWalletConnectError(null);
+                }}
+                className="shrink-0 text-xs text-slate-500 underline underline-offset-2 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
+              >
+                Disconnect
+              </button>
+            </div>
+            <button
+              type="button"
+              onClick={() => requestConfirm(connectedAddress)}
+              className="w-full rounded-lg bg-green-600 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-green-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-600 dark:bg-green-700 dark:hover:bg-green-600"
+            >
+              Claim to {shortenAddress(connectedAddress)}
+            </button>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            <WalletConnect
+              onConnected={(wallet) => {
+                setConnectedAddress(wallet.publicKey);
+                setWalletConnectError(null);
+              }}
+              onRejected={(msg) => {
+                setWalletConnectError(msg ?? 'Wallet connection was declined. You can enter your address manually below.');
+              }}
+            />
+            {walletConnectError && (
+              <p
+                role="alert"
+                className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-2 dark:text-amber-300 dark:bg-amber-950 dark:border-amber-800"
+              >
+                {walletConnectError}
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center gap-2 text-xs text-slate-400 dark:text-slate-500">
+        <hr className="flex-1 border-slate-200 dark:border-slate-700" />
+        <span>or enter address manually</span>
+        <hr className="flex-1 border-slate-200 dark:border-slate-700" />
+      </div>
+
+      {/* Manual address entry — original new-wallet path */}
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400 mb-2">
+          New to Stellar?
+        </p>
+        <div className="space-y-3">
+          {rateLimit !== undefined && <RateLimitBanner retryAfter={rateLimit} />}
+          {claimError && (
+            <p
+              role="alert"
+              className="text-sm text-red-700 bg-red-50 border border-red-200 rounded px-3 py-2 dark:text-red-300 dark:bg-red-950 dark:border-red-800"
+            >
+              {claimError}
+            </p>
+          )}
+
+          <div>
+            <label
+              htmlFor="destination-address"
+              className="mb-1 block text-xs font-medium text-slate-700 dark:text-slate-300"
+            >
+              Your Stellar wallet address
+            </label>
+            <input
+              id="destination-address"
+              type="text"
+              inputMode="text"
+              autoComplete="off"
+              spellCheck={false}
+              placeholder="G..."
+              value={destinationAddress}
+              onChange={(e) => setDestinationAddress(e.target.value.trim())}
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 font-mono text-xs text-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-600 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:focus-visible:outline-green-500"
+            />
+            {destinationAddress.length > 0 && !manualIsValid && (
+              <p className="mt-1 text-xs text-red-600 dark:text-red-400">
+                Enter a valid Stellar public key (starts with G, 56 characters).
+              </p>
+            )}
+          </div>
+
+          <button
+            type="button"
+            onClick={() => requestConfirm(destinationAddress)}
+            disabled={!manualIsValid}
+            className="w-full rounded-lg bg-green-600 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-green-700 disabled:opacity-60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-600 dark:bg-green-700 dark:hover:bg-green-600"
+          >
+            Claim now
+          </button>
+        </div>
+      </div>
+
+      <div className="pt-1">
+        <ChainSelector />
+      </div>
+
+      <p className="text-xs text-slate-500 dark:text-slate-400">
+        Funds are held on-chain. Claiming transfers them directly to your Stellar wallet.
+      </p>
+    </div>
+  );
+}
+
+function NotReadyPanel({ status }: { status: ClaimStatus }) {
+  const message =
+    status === AccountStatus.INITIALIZING
+      ? 'The sender is setting up this payment. This page will update automatically once it is ready.'
+      : 'The sender\u2019s payment hasn\u2019t confirmed on-chain yet. This usually takes a few seconds to a couple of minutes.';
+  return (
+    <div className="flex items-center gap-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-800 dark:bg-amber-950">
+      <span
+        className="h-4 w-4 shrink-0 animate-spin rounded-full border-2 border-amber-400 border-t-transparent dark:border-amber-500"
+        aria-hidden="true"
+      />
+      <p className="text-sm text-amber-800 dark:text-amber-300">{message}</p>
+    </div>
+  );
+}
+
+/**
+ * #433: ProcessingPanel covers CLAIMING and PARTIAL_SWEEP.
+ * CLAIMING = "funds are moving" — distinct visual from the initial claim step.
+ * PARTIAL_SWEEP = nearly done, can retry.
+ */
+function ProcessingPanel({ status, sweepNote }: { status: ClaimStatus; sweepNote?: string }) {
+  const isClaiming = status === AccountStatus.CLAIMING;
+  return (
+    <div className="space-y-3">
+      <div
+        className={`flex items-start gap-3 rounded-lg border px-4 py-3 ${
+          isClaiming
+            ? 'border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-950'
+            : 'border-indigo-200 bg-indigo-50 dark:border-indigo-800 dark:bg-indigo-950'
+        }`}
+      >
+        <span
+          className={`mt-0.5 h-4 w-4 shrink-0 animate-spin rounded-full border-2 border-t-transparent ${
+            isClaiming
+              ? 'border-blue-400 dark:border-blue-500'
+              : 'border-indigo-400 dark:border-indigo-500'
+          }`}
+          aria-hidden="true"
+        />
+        <div>
+          {isClaiming ? (
+            <>
+              <p className="text-sm font-semibold text-blue-800 dark:text-blue-200">
+                Funds are moving to your wallet
+              </p>
+              <p className="text-xs text-blue-600 mt-0.5 dark:text-blue-400">
+                Your transfer is being processed on the Stellar network. This page will update
+                automatically — it typically takes a few seconds.
+              </p>
+            </>
+          ) : (
+            <>
+              <p className="text-sm font-semibold text-indigo-800 dark:text-indigo-200">
+                Almost there — finalizing your transfer
+              </p>
+              <p className="text-xs text-indigo-600 mt-0.5 dark:text-indigo-400">
+                Your claim was authorized and the sweep is finishing up. If it&apos;s taking longer
+                than a few minutes, you can retry below.
+              </p>
+            </>
+          )}
+        </div>
+      </div>
+      {sweepNote && (
+        <p className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-2 dark:text-amber-300 dark:bg-amber-950 dark:border-amber-800">
+          🛠 Dev note: {sweepNote}
+        </p>
+      )}
+    </div>
+  );
+}
+
+/**
+ * #435: ClaimedPanel distinguishes "you claimed this" vs "someone else claimed this".
+ * Never offers a re-claim action. Always links to support for disputes.
+ */
+function ClaimedPanel({
+  claimedByMe,
+  sweepDestination,
+  sweepAmountStroops,
+  assetCode,
+  supportEmail,
+}: Pick<
+  ClaimStatusCardProps,
+  'claimedByMe' | 'sweepDestination' | 'sweepAmountStroops' | 'assetCode' | 'supportEmail'
+>) {
+  if (claimedByMe) {
+    // "You claimed this" — success confirmation view.
+    return (
+      <div className="space-y-3">
+        <div className="flex items-start gap-3 rounded-lg border border-green-200 bg-green-50 px-4 py-3 dark:border-green-800 dark:bg-green-950">
+          <svg
+            aria-hidden="true"
+            className="mt-0.5 h-5 w-5 shrink-0 text-green-600 dark:text-green-400"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
+          </svg>
+          <div className="min-w-0">
+            <p className="text-sm font-semibold text-green-800 dark:text-green-200">
+              You already claimed this payment
+            </p>
+            {sweepAmountStroops && (
+              <p className="text-sm text-green-700 mt-0.5 dark:text-green-300">
+                {stroopsToDisplay(sweepAmountStroops, assetCode)} was sent to your wallet.
+              </p>
+            )}
+            {sweepDestination && (
+              <p className="mt-1 break-all font-mono text-xs text-green-600 dark:text-green-400">
+                {sweepDestination}
+              </p>
+            )}
+          </div>
+        </div>
+        <p className="text-xs text-slate-500 dark:text-slate-400">
+          Check your Stellar wallet for the incoming transfer. It may take a moment to appear.
+          {supportEmail && (
+            <>
+              {' '}If you have questions,{' '}
+              <a
+                href={`mailto:${supportEmail}`}
+                className="underline underline-offset-2 hover:text-slate-700 dark:hover:text-slate-200"
+              >
+                contact support
+              </a>
+              .
+            </>
+          )}
+        </p>
+      </div>
+    );
+  }
+
+  // "Claimed by someone else" — could be a forwarded / shared link.
+  return (
+    <div className="space-y-3">
+      <div className="flex items-start gap-3 rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 dark:border-slate-700 dark:bg-slate-800">
+        <svg
+          aria-hidden="true"
+          className="mt-0.5 h-5 w-5 shrink-0 text-slate-400 dark:text-slate-500"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+          />
+        </svg>
+        <div>
+          <p className="text-sm font-semibold text-slate-800 dark:text-slate-200">
+            This payment has already been claimed
+          </p>
+          <p className="text-xs text-slate-600 mt-0.5 dark:text-slate-400">
+            Each claim link can only be used once. The funds have been transferred to a wallet.
+          </p>
+        </div>
+      </div>
+      <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300">
+        <p className="font-medium text-slate-800 mb-1 dark:text-slate-200">
+          Think this is a mistake?
+        </p>
+        <ul className="list-disc list-inside space-y-1 text-xs text-slate-600 dark:text-slate-400">
+          <li>If you received this link from someone, it may have been used already.</li>
+          <li>Contact the sender and ask them to send you a new payment link.</li>
+          {supportEmail && (
+            <li>
+              For disputes, reach us at{' '}
+              <a
+                href={`mailto:${supportEmail}`}
+                className="underline underline-offset-2 hover:text-slate-900 dark:hover:text-slate-100"
+              >
+                {supportEmail}
+              </a>
+              .
+            </li>
+          )}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * #434: ExpiredPanel — visually distinct from other error states (amber vs red),
+ * explains that funds are automatically returned to the sender, no claim action offered.
+ */
+function ExpiredPanel({
+  expiresAt,
+  supportEmail,
+}: Pick<ClaimStatusCardProps, 'expiresAt' | 'supportEmail'>) {
+  return (
+    <div className="space-y-3">
+      <div className="flex items-start gap-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-800 dark:bg-amber-950">
+        <svg
+          aria-hidden="true"
+          className="mt-0.5 h-5 w-5 shrink-0 text-amber-500 dark:text-amber-400"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
+        </svg>
+        <div>
+          <p className="text-sm font-semibold text-amber-800 dark:text-amber-200">
+            This claim link has expired
+          </p>
+          {expiresAt && (
+            <p className="text-xs text-amber-700 mt-0.5 dark:text-amber-400">
+              Expired on {formatExpiry(expiresAt)}.
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-amber-100 bg-amber-50 px-4 py-3 text-sm dark:border-amber-900 dark:bg-amber-950">
+        <p className="font-medium text-amber-800 mb-1 dark:text-amber-200">What happened?</p>
+        <ul className="list-disc list-inside space-y-1 text-xs text-amber-700 dark:text-amber-300">
+          <li>
+            The funds from this link have been <strong>automatically returned to the sender</strong>
+            — no money has been lost.
+          </li>
+          <li>Contact the sender and ask them to create a new payment link for you.</li>
+          {supportEmail && (
+            <li>
+              Need help?{' '}
+              <a
+                href={`mailto:${supportEmail}`}
+                className="underline underline-offset-2 hover:text-amber-900 dark:hover:text-amber-100"
+              >
+                {supportEmail}
+              </a>
+            </li>
+          )}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+function FailedPanel({ supportEmail }: Pick<ClaimStatusCardProps, 'supportEmail'>) {
+  return (
+    <div className="space-y-3">
+      <div className="flex items-start gap-3 rounded-lg border border-red-200 bg-red-50 px-4 py-3 dark:border-red-800 dark:bg-red-950">
+        <svg
+          aria-hidden="true"
+          className="mt-0.5 h-5 w-5 shrink-0 text-red-500 dark:text-red-400"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
+        </svg>
+        <div>
+          <p className="text-sm font-semibold text-red-800 dark:text-red-300">
+            This payment couldn&apos;t be set up
+          </p>
+          <p className="text-xs text-red-600 mt-0.5 dark:text-red-400">
+            Something went wrong while creating or funding this payment. It has not been claimed and
+            no funds have moved.
+          </p>
+        </div>
+      </div>
+      {supportEmail && (
+        <p className="text-xs text-slate-500 dark:text-slate-400">
+          Contact the sender, or reach us at{' '}
+          <a
+            href={`mailto:${supportEmail}`}
+            className="underline underline-offset-2 hover:text-slate-900 dark:hover:text-slate-100"
+          >
+            {supportEmail}
+          </a>
+          .
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+/**
+ * Renders the correct UI for a claim token based on its current account
+ * status. Every value of AccountStatus is handled explicitly (Issue 5) —
+ * there is no silent "unknown status" fallback.
+ */
+export function ClaimStatusCard({
+  status,
+  amountStroops,
+  assetCode = 'XLM',
+  expiresAt,
+  memo,
+  onClaim,
+  sweepNote,
+  supportEmail,
+  claimedByMe,
+  sweepDestination,
+  sweepAmountStroops,
+}: ClaimStatusCardProps) {
+  // Derive header for CLAIMED based on claimedByMe
+  const header =
+    status === AccountStatus.CLAIMED
+      ? claimedByMe
+        ? 'Payment claimed by you'
+        : 'Payment already claimed'
+      : HEADERS[status];
+
+  return (
+    <article
+      aria-label={`Claim status: ${status}`}
+      aria-live="polite"
+      aria-atomic="true"
+      aria-relevant="additions text"
+      className={`rounded-xl border-2 ${BORDER_COLORS[status]} bg-white p-5 shadow-sm space-y-4 dark:bg-slate-900`}
+    >
+      <header className="flex items-center justify-between">
+        <h2 className="text-base font-semibold text-slate-900 dark:text-slate-100">{header}</h2>
+        <StatusBadge status={status} />
+      </header>
+
+      <hr className="border-slate-100 dark:border-slate-800" />
+
+      {(status === AccountStatus.INITIALIZING || status === AccountStatus.PENDING_PAYMENT) && (
+        <NotReadyPanel status={status} />
+      )}
+      {status === AccountStatus.PENDING_CLAIM && (
+        <AvailablePanel
+          amountStroops={amountStroops}
+          assetCode={assetCode}
+          expiresAt={expiresAt}
+          memo={memo}
+          onClaim={onClaim}
+          sweepNote={sweepNote}
+        />
+      )}
+      {(status === AccountStatus.CLAIMING || status === AccountStatus.PARTIAL_SWEEP) && (
+        <ProcessingPanel status={status} sweepNote={sweepNote} />
+      )}
+      {status === AccountStatus.CLAIMED && (
+        <ClaimedPanel
+          claimedByMe={claimedByMe}
+          sweepDestination={sweepDestination}
+          sweepAmountStroops={sweepAmountStroops}
+          assetCode={assetCode}
+          supportEmail={supportEmail}
+        />
+      )}
+      {status === AccountStatus.EXPIRED && (
+        <ExpiredPanel expiresAt={expiresAt} supportEmail={supportEmail} />
+      )}
+      {status === AccountStatus.FAILED && <FailedPanel supportEmail={supportEmail} />}
+    </article>
+  );
+}
 
 /**
  * ClaimStatus now mirrors the backend's real AccountStatus enum (Issue 5)

--- a/frontend/components/clainStatusCard.test.tsx
+++ b/frontend/components/clainStatusCard.test.tsx
@@ -17,6 +17,24 @@ vi.mock('@/components/chain-selector', () => ({
   ChainSelector: () => <div data-testid="chain-selector" />,
 }));
 
+// #432: mock WalletConnect so we can test it independently of Freighter
+vi.mock('@/components/wallet-connect', () => ({
+  WalletConnect: ({
+    onConnected,
+    onRejected,
+  }: {
+    onConnected?: (w: { publicKey: string }) => void;
+    onRejected?: (msg: string) => void;
+  }) => (
+    <div>
+      <button onClick={() => onConnected?.({ publicKey: 'G' + 'B'.repeat(55) })}>
+        Connect Freighter Wallet
+      </button>
+      <button onClick={() => onRejected?.('User rejected')}>Simulate reject</button>
+    </div>
+  ),
+}));
+
 // A valid-looking Stellar public key (G + 55 base32 chars).
 const VALID_ADDRESS = 'G' + 'A'.repeat(55);
 
@@ -75,7 +93,17 @@ describe('ClaimStatusCard', () => {
       expect(button).toBeEnabled();
     });
 
-    it('calls onClaim with the destination address and shows success state', async () => {
+    // #432: wallet-connect path is shown alongside manual entry
+    it('shows the wallet connect option alongside manual entry', () => {
+      render(<ClaimStatusCard status={AccountStatus.PENDING_CLAIM} amountStroops="10000000" />);
+      expect(screen.getByText(/already have a stellar wallet/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /connect freighter wallet/i })).toBeInTheDocument();
+      expect(screen.getByText(/new to stellar/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/your stellar wallet address/i)).toBeInTheDocument();
+    });
+
+    // #432: wallet connect prefills address and shows confirmation before sweep
+    it('prefills address from wallet connect and shows confirmation step', async () => {
       const user = userEvent.setup({ delay: null });
       const onClaim = vi.fn().mockResolvedValue(undefined);
       render(
@@ -83,16 +111,73 @@ describe('ClaimStatusCard', () => {
           status={AccountStatus.PENDING_CLAIM}
           amountStroops="10000000"
           onClaim={onClaim}
-          sweepNote="stub: sweep pending"
+        />,
+      );
+
+      // Connect wallet via mock
+      await user.click(screen.getByRole('button', { name: /connect freighter wallet/i }));
+
+      // Should show connected address and a "Claim to …" button
+      expect(await screen.findByText(/freighter connected/i)).toBeInTheDocument();
+      const claimToBtn = screen.getByRole('button', { name: /claim to/i });
+      expect(claimToBtn).toBeInTheDocument();
+
+      // Click it → should show confirmation dialog
+      await user.click(claimToBtn);
+      expect(await screen.findByRole('dialog', { name: /confirm destination address/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /confirm & send/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /back/i })).toBeInTheDocument();
+
+      // onClaim should NOT have been called yet
+      expect(onClaim).not.toHaveBeenCalled();
+    });
+
+    // #432: wallet connect rejection shows contextual fallback message
+    it('shows a non-alarming message when wallet connect is rejected', async () => {
+      const user = userEvent.setup({ delay: null });
+      render(<ClaimStatusCard status={AccountStatus.PENDING_CLAIM} amountStroops="10000000" />);
+
+      await user.click(screen.getByRole('button', { name: /simulate reject/i }));
+
+      expect(await screen.findByRole('alert')).toHaveTextContent(/user rejected/i);
+      // Manual entry should still be accessible
+      expect(screen.getByLabelText(/your stellar wallet address/i)).toBeInTheDocument();
+    });
+
+    // #433: claim now → confirmation → confirm & send → sweep in progress → success
+    it('shows confirmation step, then sweep-in-progress, then final success state', async () => {
+      const user = userEvent.setup({ delay: null });
+      const onClaim = vi.fn().mockResolvedValue(undefined);
+      render(
+        <ClaimStatusCard
+          status={AccountStatus.PENDING_CLAIM}
+          amountStroops="10000000"
+          assetCode="XLM"
+          onClaim={onClaim}
         />,
       );
 
       setDestinationAddress(VALID_ADDRESS);
       await user.click(screen.getByRole('button', { name: /claim now/i }));
 
+      // Confirmation step shown
+      expect(await screen.findByRole('dialog', { name: /confirm destination address/i })).toBeInTheDocument();
+
+      // Confirm
+      await user.click(screen.getByRole('button', { name: /confirm & send/i }));
+
       await waitFor(() => expect(onClaim).toHaveBeenCalledWith(VALID_ADDRESS));
-      expect(await screen.findByText(/claim submitted/i)).toBeInTheDocument();
-      expect(screen.getByText(/stub: sweep pending/)).toBeInTheDocument();
+
+      // #433: sweep-in-progress state shown
+      expect(await screen.findByText(/funds are moving to your wallet/i)).toBeInTheDocument();
+
+      // #433: final success state appears after 2s (we fake timers are not needed as we just await)
+      await waitFor(
+        () => expect(screen.getByText(/payment sent successfully/i)).toBeInTheDocument(),
+        { timeout: 3500 },
+      );
+      expect(screen.getByText(/1\.00 XLM/)).toBeInTheDocument();
+      expect(screen.getByText(VALID_ADDRESS)).toBeInTheDocument();
     });
 
     it('shows a rate limit banner when onClaim throws RateLimitError', async () => {
@@ -109,9 +194,13 @@ describe('ClaimStatusCard', () => {
       setDestinationAddress(VALID_ADDRESS);
       await user.click(screen.getByRole('button', { name: /claim now/i }));
 
+      // Confirmation step
+      expect(await screen.findByRole('dialog', { name: /confirm destination address/i })).toBeInTheDocument();
+      await user.click(screen.getByRole('button', { name: /confirm & send/i }));
+
       expect(await screen.findByTestId('rate-limit-banner')).toHaveTextContent('retry: 30');
-      // Should not show the success state.
-      expect(screen.queryByText(/claim submitted/i)).not.toBeInTheDocument();
+      // Should not show the success state
+      expect(screen.queryByText(/payment sent successfully/i)).not.toBeInTheDocument();
     });
 
     it('shows a visible error message for a non-rate-limit rejection', async () => {
@@ -127,33 +216,23 @@ describe('ClaimStatusCard', () => {
 
       setDestinationAddress(VALID_ADDRESS);
       await user.click(screen.getByRole('button', { name: /claim now/i }));
+      await user.click(await screen.findByRole('button', { name: /confirm & send/i }));
 
       expect(await screen.findByRole('alert')).toHaveTextContent('boom');
-      expect(screen.queryByText(/claim submitted/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/payment sent successfully/i)).not.toBeInTheDocument();
     });
 
-    it('clears a previous error on the next claim attempt', async () => {
+    it('back button on confirmation returns to the address entry form', async () => {
       const user = userEvent.setup({ delay: null });
-      const onClaim = vi
-        .fn()
-        .mockRejectedValueOnce(new Error('boom'))
-        .mockResolvedValueOnce(undefined);
-      render(
-        <ClaimStatusCard
-          status={AccountStatus.PENDING_CLAIM}
-          amountStroops="10000000"
-          onClaim={onClaim}
-        />,
-      );
+      render(<ClaimStatusCard status={AccountStatus.PENDING_CLAIM} amountStroops="10000000" />);
 
       setDestinationAddress(VALID_ADDRESS);
-      const button = screen.getByRole('button', { name: /claim now/i });
-      await user.click(button);
-      expect(await screen.findByRole('alert')).toBeInTheDocument();
+      await user.click(screen.getByRole('button', { name: /claim now/i }));
+      expect(await screen.findByRole('dialog', { name: /confirm destination address/i })).toBeInTheDocument();
 
-      await user.click(button);
-      await waitFor(() => expect(screen.queryByRole('alert')).not.toBeInTheDocument());
-      expect(await screen.findByText(/claim submitted/i)).toBeInTheDocument();
+      await user.click(screen.getByRole('button', { name: /back/i }));
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      expect(screen.getByLabelText(/your stellar wallet address/i)).toBeInTheDocument();
     });
 
     it('renders the ChainSelector', () => {
@@ -164,13 +243,14 @@ describe('ClaimStatusCard', () => {
 
   // ─── CLAIMING / PARTIAL_SWEEP ──────────────────────────────────────────
 
-  it('shows a processing message for CLAIMING', () => {
+  // #433: CLAIMING shows "funds are moving" distinct from initial claim step
+  it('shows a "funds are moving" message for CLAIMING', () => {
     render(<ClaimStatusCard status={AccountStatus.CLAIMING} />);
-    expect(screen.getByText('Claim in progress')).toBeInTheDocument();
-    expect(screen.getByText(/being processed on-chain/i)).toBeInTheDocument();
+    expect(screen.getByText('Funds are moving to your wallet')).toBeInTheDocument();
+    expect(screen.getByText(/being processed on the Stellar network/i)).toBeInTheDocument();
   });
 
-  it('shows a retry hint and sweep note for PARTIAL_SWEEP', () => {
+  it('shows a finalizing message and sweep note for PARTIAL_SWEEP', () => {
     render(
       <ClaimStatusCard
         status={AccountStatus.PARTIAL_SWEEP}
@@ -178,27 +258,78 @@ describe('ClaimStatusCard', () => {
       />,
     );
     expect(screen.getByText('Finishing up your claim')).toBeInTheDocument();
-    expect(screen.getByText(/tap claim now to retry/i)).toBeInTheDocument();
+    expect(screen.getByText(/finalizing your transfer/i)).toBeInTheDocument();
     expect(screen.getByText(/1 of 2 legs complete/)).toBeInTheDocument();
   });
 
   // ─── CLAIMED ────────────────────────────────────────────────────────────
 
-  it('shows the claimed state', () => {
-    render(<ClaimStatusCard status={AccountStatus.CLAIMED} />);
-    // "Payment already claimed" appears twice (card header + panel body),
-    // so scope to the header role instead of a plain text match.
-    expect(screen.getByRole('heading', { name: 'Payment already claimed' })).toBeInTheDocument();
-    expect(screen.getByText(/transferred to the recipient/i)).toBeInTheDocument();
+  // #435: "claimed by someone else" state — neutral, not alarming
+  it('shows the "claimed by someone else" state when claimedByMe is false', () => {
+    render(<ClaimStatusCard status={AccountStatus.CLAIMED} claimedByMe={false} />);
+    expect(
+      screen.getByRole('heading', { name: 'Payment already claimed' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/each claim link can only be used once/i)).toBeInTheDocument();
+    // Should NOT offer a claim action
+    expect(screen.queryByRole('button', { name: /claim/i })).not.toBeInTheDocument();
+  });
+
+  // #435: "claimed by you" state — success confirmation
+  it('shows the "claimed by you" success state when claimedByMe is true', () => {
+    render(
+      <ClaimStatusCard
+        status={AccountStatus.CLAIMED}
+        claimedByMe={true}
+        sweepAmountStroops="10000000"
+        assetCode="XLM"
+        sweepDestination={VALID_ADDRESS}
+        supportEmail="support@example.com"
+      />,
+    );
+    expect(
+      screen.getByRole('heading', { name: 'Payment claimed by you' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/you already claimed this payment/i)).toBeInTheDocument();
+    expect(screen.getByText(/1\.00 XLM/)).toBeInTheDocument();
+    expect(screen.getByText(VALID_ADDRESS)).toBeInTheDocument();
+    // Should NOT offer a claim action
+    expect(screen.queryByRole('button', { name: /claim/i })).not.toBeInTheDocument();
+  });
+
+  // #435: support link shown in "claimed by someone else" state
+  it('shows a support link in the "claimed by someone else" state', () => {
+    render(
+      <ClaimStatusCard
+        status={AccountStatus.CLAIMED}
+        claimedByMe={false}
+        supportEmail="help@example.com"
+      />,
+    );
+    const link = screen.getByRole('link', { name: 'help@example.com' });
+    expect(link).toHaveAttribute('href', 'mailto:help@example.com');
   });
 
   // ─── EXPIRED ────────────────────────────────────────────────────────────
 
   describe('EXPIRED', () => {
+    // #434: visually distinct from FAILED (amber vs red)
     it('shows the expiry date when provided', () => {
       render(<ClaimStatusCard status={AccountStatus.EXPIRED} expiresAt="2026-01-01T00:00:00Z" />);
       expect(screen.getByText('Payment link expired')).toBeInTheDocument();
       expect(screen.getByText(/expired on/i)).toBeInTheDocument();
+    });
+
+    // #434: explains funds are returned to sender
+    it('explains that funds are automatically returned to the sender', () => {
+      render(<ClaimStatusCard status={AccountStatus.EXPIRED} />);
+      expect(screen.getByText(/automatically returned to the sender/i)).toBeInTheDocument();
+    });
+
+    // #434: no claim action offered
+    it('does not offer a claim action when expired', () => {
+      render(<ClaimStatusCard status={AccountStatus.EXPIRED} />);
+      expect(screen.queryByRole('button', { name: /claim/i })).not.toBeInTheDocument();
     });
 
     it('renders a mailto link when supportEmail is provided', () => {

--- a/frontend/components/wallet-connect.tsx
+++ b/frontend/components/wallet-connect.tsx
@@ -5,9 +5,15 @@ import { connectFreighter, type ConnectedWallet } from '@/lib/wallet';
 
 type WalletConnectProps = {
   onConnected?: (wallet: ConnectedWallet) => void;
+  /**
+   * #432: Called when the user explicitly declines the Freighter connection
+   * request or when Freighter is not installed. The message explains what
+   * happened so the parent can display it contextually.
+   */
+  onRejected?: (message: string) => void;
 };
 
-export function WalletConnect({ onConnected }: WalletConnectProps) {
+export function WalletConnect({ onConnected, onRejected }: WalletConnectProps) {
   const [wallet, setWallet] = useState<ConnectedWallet | null>(null);
   const [status, setStatus] = useState<'idle' | 'connecting' | 'error'>('idle');
   const [error, setError] = useState<string | null>(null);
@@ -22,7 +28,10 @@ export function WalletConnect({ onConnected }: WalletConnectProps) {
       onConnected?.(connected);
     } catch (err) {
       setStatus('error');
-      setError(err instanceof Error ? err.message : 'Failed to connect wallet.');
+      const message = err instanceof Error ? err.message : 'Failed to connect wallet.';
+      setError(message);
+      // #432: surface rejection to parent so it can show contextual guidance
+      onRejected?.(message);
     }
   }
 

--- a/frontend/lib/claim-view.ts
+++ b/frontend/lib/claim-view.ts
@@ -7,6 +7,22 @@ export interface ClaimView {
   assetCode?: string;
   expiresAt?: string;
   sweepNote?: string;
+  /**
+   * #435: true when the 409 response indicates the token was claimed in this
+   * browser session (we wrote it to sessionStorage on a successful claim).
+   * undefined / false means claimed by someone else.
+   */
+  claimedByMe?: boolean;
+  /**
+   * #433: destination wallet address reported by the API after a successful
+   * sweep, shown in the final success state.
+   */
+  sweepDestination?: string;
+  /**
+   * #433: amount confirmed swept (in stroops), reported by the API.
+   * May differ from amountStroops when fees are deducted.
+   */
+  sweepAmountStroops?: string;
 }
 
 export function toStroops(decimalAmount: string): string {
@@ -14,6 +30,34 @@ export function toStroops(decimalAmount: string): string {
   const num = parseFloat(decimalAmount);
   if (Number.isNaN(num)) return '0';
   return String(Math.round(num * 10_000_000));
+}
+
+/** SessionStorage key used to record tokens this browser session claimed. */
+const CLAIMED_TOKENS_KEY = 'bridgelet_claimed_tokens';
+
+/** Mark a token as claimed by the current browser session. */
+export function markTokenClaimed(claimToken: string): void {
+  try {
+    const raw = sessionStorage.getItem(CLAIMED_TOKENS_KEY);
+    const tokens: string[] = raw ? (JSON.parse(raw) as string[]) : [];
+    if (!tokens.includes(claimToken)) {
+      tokens.push(claimToken);
+      sessionStorage.setItem(CLAIMED_TOKENS_KEY, JSON.stringify(tokens));
+    }
+  } catch {
+    // sessionStorage may be unavailable in some environments — fail silently.
+  }
+}
+
+/** Returns true if this browser session previously claimed the given token. */
+function wasClaimedByMe(claimToken: string): boolean {
+  try {
+    const raw = sessionStorage.getItem(CLAIMED_TOKENS_KEY);
+    if (!raw) return false;
+    return (JSON.parse(raw) as string[]).includes(claimToken);
+  } catch {
+    return false;
+  }
 }
 
 export async function loadClaimView(claimToken: string): Promise<ClaimView> {
@@ -28,7 +72,13 @@ export async function loadClaimView(claimToken: string): Promise<ClaimView> {
     };
   } catch (err) {
     if (err instanceof BridgeletApiError) {
-      if (err.statusCode === 409) return { status: AccountStatus.CLAIMED };
+      if (err.statusCode === 409) {
+        return {
+          status: AccountStatus.CLAIMED,
+          // #435: check if this session was the one that claimed it
+          claimedByMe: wasClaimedByMe(claimToken),
+        };
+      }
       if (err.statusCode === 400) return { status: AccountStatus.PENDING_PAYMENT };
       if (err.statusCode === 401) return { status: AccountStatus.EXPIRED };
     }


### PR DESCRIPTION
## Summary

Resolves four issues related to the claim flow UI in `frontend/app/claim/[token]/`.

## Changes

### #435 — Already-claimed error state
- Split `ClaimedPanel` into two distinct sub-states: **"claimed by you"** (green success confirmation) and **"claimed by someone else"** (neutral informational).
- `ClaimView` gains a `claimedByMe` boolean, written to `sessionStorage` by `markTokenClaimed()` when a successful claim is made in the current session.
- `loadClaimView` reads `sessionStorage` on a 409 response to determine which sub-state to show.
- No re-claim action is offered in either case. A support email link is shown for disputes.

### #434 — Expired-link error state
- `ExpiredPanel` now uses an **amber** colour scheme (not red) to visually differentiate expiry from failures.
- Copy updated to clearly state that funds are **automatically returned to the sender** — no money is lost.
- No claim action is rendered when the status is `EXPIRED`.

### #433 — Auto-sweep confirmation UI
- After clicking **Claim now → Confirm & send**, a **sweep-in-progress** spinner state is shown (`role="status"`) distinct from the initial claim step.
- A **final success card** then appears with the destination wallet address and the amount sent.
- `CLAIMING` panel updated with a "Funds are moving to your wallet" heading.
- `PARTIAL_SWEEP` panel shows "Finalizing your transfer" copy distinct from `CLAIMING`.

### #432 — Existing-wallet connect path
- `AvailablePanel` now shows **WalletConnect (Freighter) alongside the manual address entry** — not hidden behind a toggle.
- Both paths go through a **confirmation step** (address + amount review) before the sweep fires.
- `WalletConnect` gains an `onRejected` callback so connection failures surface as contextual amber notices, keeping the manual path accessible.

## Files changed
- `frontend/lib/claim-view.ts` — new fields + `markTokenClaimed` / `wasClaimedByMe`
- `frontend/components/claim-status-card.tsx` — updated panels for all four issues
- `frontend/components/wallet-connect.tsx` — `onRejected` prop
- `frontend/app/claim/[token]/claim-page-client.tsx` — passes new props, calls `markTokenClaimed`
- `frontend/components/clainStatusCard.test.tsx` — updated and new tests

## Closes

Closes #432
Closes #433
Closes #434
Closes #435
