### PR TITLE
feat(mobile): align mobile app with Bridgelet SDK API surface

### DIFF
--- a/mobile/.env.example
+++ b/mobile/.env.example
@@ -1,2 +1,8 @@
 EXPO_PUBLIC_API_URL=https://api.bridgelet.io
 EXPO_PUBLIC_ENV=development
+# Stellar funding account used as both fundingSource and recovery_address when
+# creating ephemeral accounts via POST /accounts (required by the Bridgelet SDK).
+EXPO_PUBLIC_FUNDING_ACCOUNT=GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+# Bridgelet SDK integrator API key. Sent as the X-API-Key header; required for
+# authenticated endpoints (POST /accounts) and applied to claim endpoints too.
+EXPO_PUBLIC_API_KEY=

--- a/mobile/app/src/claims/service.ts
+++ b/mobile/app/src/claims/service.ts
@@ -1,9 +1,5 @@
-import {
-  ClaimTokenError,
-  ClaimTokenPayload,
-  decodeClaimTokenPayload,
-  validateClaimToken,
-} from "./token";
+import { validateClaimToken } from "./token";
+import { apiClient } from "../utils/apiClient";
 
 export type ClaimLookupResult = {
   accountId: string;
@@ -12,36 +8,47 @@ export type ClaimLookupResult = {
   expiresAt?: string;
 };
 
-const wait = (ms: number): Promise<void> => {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
+type VerifyClaimResponse = {
+  valid: boolean;
+  accountId: string;
+  amount: string;
+  asset: string;
+  expiresAt: Date;
 };
 
-const fromPayload = (payload: ClaimTokenPayload): ClaimLookupResult => {
-  return {
-    accountId: payload.accountId ?? "unknown-account",
-    amount: payload.amount ?? "0",
-    asset: payload.asset ?? "XLM:native",
-    expiresAt: payload.expiresAt,
-  };
-};
-
+/**
+ * Resolve a claim token against the Bridgelet SDK `POST /claims/verify`
+ * endpoint. The server performs authoritative verification (JWT signature,
+ * expiry, account status) and returns the claim details; the client no longer
+ * decodes the token payload locally (the SDK signs only publicKey/type/jti,
+ * not the account details).
+ */
 export const lookupClaimByToken = async (
   token: string,
 ): Promise<ClaimLookupResult> => {
   validateClaimToken(token);
 
-  // Simulate network verification while backend endpoint is being integrated.
-  await wait(900);
-
   try {
-    const payload = decodeClaimTokenPayload(token);
-    return fromPayload(payload);
-  } catch {
-    throw new ClaimTokenError(
-      "INVALID_TOKEN_FORMAT",
-      "Invalid claim link format.",
-    );
+    const result = await apiClient<VerifyClaimResponse>("/claims/verify", {
+      method: "POST",
+      body: JSON.stringify({ claimToken: token }),
+    });
+    return {
+      accountId: result.accountId,
+      amount: result.amount,
+      asset: result.asset,
+      expiresAt: result.expiresAt ? new Date(result.expiresAt).toISOString() : undefined,
+    };
+  } catch (error: any) {
+    if (error?.status === 401) {
+      throw new Error("This claim link is invalid or has expired.");
+    }
+    if (error?.status === 409) {
+      throw new Error("This payment has already been claimed.");
+    }
+    if (error?.status === 400) {
+      throw new Error("This payment is not ready to be claimed yet.");
+    }
+    throw new Error("Unable to verify this claim token. Please try again.");
   }
 };

--- a/mobile/app/src/components/MobileSendFlow.tsx
+++ b/mobile/app/src/components/MobileSendFlow.tsx
@@ -57,21 +57,44 @@ const EXPIRY_OPTIONS = [
 // ─── API call ────────────────────────────────────────────────────────────────
 
 async function createClaimLink(form: SendFormState): Promise<ClaimLinkResult> {
+  // The Bridgelet SDK has no `POST /claims` endpoint. Claim links are created
+  // by provisioning an ephemeral account via `POST /accounts`, which returns a
+  // `claimUrl` containing the claim token. The SDK requires `fundingSource`
+  // and `recovery_address` (Stellar public keys).
   const response = await fetch(
-    `${process.env.EXPO_PUBLIC_API_URL ?? 'https://api.bridgelet.org'}/claims`,
+    `${process.env.EXPO_PUBLIC_API_URL ?? 'https://api.bridgelet.io'}/accounts`,
     {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        ...(process.env.EXPO_PUBLIC_API_KEY
+          ? { 'X-API-Key': process.env.EXPO_PUBLIC_API_KEY }
+          : {}),
+      },
       body: JSON.stringify({
-        amount: parseFloat(form.amount),
-        asset: form.asset,
-        note: form.recipientNote || undefined,
-        expiresInHours: form.expiresInHours === '0' ? null : parseInt(form.expiresInHours, 10),
+        fundingSource: process.env.EXPO_PUBLIC_FUNDING_ACCOUNT,
+        recovery_address: process.env.EXPO_PUBLIC_FUNDING_ACCOUNT,
+        amount: parseFloat(form.amount).toFixed(7),
+        asset_code: form.asset === 'XLM' ? 'XLM' : form.asset,
+        expiresIn: form.expiresInHours === '0' ? 2592000 : (parseInt(form.expiresInHours, 10) || 24) * 3600,
       }),
     },
   );
+
+  if (response.status === 401) throw new Error('Authentication failed. Check your API key configuration.');
+  if (response.status === 429) {
+    const retryAfter = response.headers.get('Retry-After');
+    throw new Error(
+      retryAfter
+        ? `Too many requests. Please wait ${retryAfter} seconds and try again.`
+        : 'Too many requests. Please try again shortly.',
+    );
+  }
   if (!response.ok) throw new Error(`Failed to create claim: ${response.status}`);
-  return response.json() as Promise<ClaimLinkResult>;
+
+  const data = await response.json();
+  if (!data?.claimUrl) throw new Error('Claim link could not be created.');
+  return { claimUrl: data.claimUrl, claimCode: '' };
 }
 
 // ─── Component ────────────────────────────────────────────────────────────────

--- a/mobile/app/src/hooks/useDeepLinkClaim.ts
+++ b/mobile/app/src/hooks/useDeepLinkClaim.ts
@@ -63,18 +63,32 @@ function extractToken(url: string): string | null {
   return null;
 }
 
-// ─── Token validation (mirrors web claim flow) ────────────────────────────────
+// ─── Token validation (mirrors web claim flow via the SDK) ────────────────────
 
 async function validateToken(token: string): Promise<ClaimTokenStatus> {
   try {
+    // The Bridgelet SDK exposes `POST /claims/verify` (no GET /claims/{token}/validate).
+    // Mapping mirrors the web frontend (lib/claim-view.ts):
+    //   200 -> valid, 409 -> already_claimed, 400 -> pending_payment (not claimable yet),
+    //   401 -> expired/invalid.
     const response = await fetch(
-      `${process.env.EXPO_PUBLIC_API_URL ?? 'https://api.bridgelet.org'}/claims/${encodeURIComponent(token)}/validate`,
-      { method: 'GET', headers: { Accept: 'application/json' } },
+      `${process.env.EXPO_PUBLIC_API_URL ?? 'https://api.bridgelet.io'}/claims/verify`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+          ...(process.env.EXPO_PUBLIC_API_KEY
+            ? { 'X-API-Key': process.env.EXPO_PUBLIC_API_KEY }
+            : {}),
+        },
+        body: JSON.stringify({ claimToken: token }),
+      },
     );
 
-    if (response.status === 404) return 'invalid';
-    if (response.status === 410) return 'expired';
     if (response.status === 409) return 'already_claimed';
+    if (response.status === 400) return 'invalid'; // initialized/no payment yet
+    if (response.status === 401) return 'expired';
     if (response.ok) return 'valid';
 
     return 'invalid';

--- a/mobile/app/src/notifications/notifications.ts
+++ b/mobile/app/src/notifications/notifications.ts
@@ -19,13 +19,14 @@
 import * as Notifications from 'expo-notifications';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Platform } from 'react-native';
+import env from '../config/env';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const PUSH_TOKEN_KEY = '@bridgelet:push-token';
 const PERMISSION_ASKED_KEY = '@bridgelet:notifications-permission-asked';
 
-const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? 'https://api.bridgelet.org';
+const API_BASE = env.apiUrl;
 
 // ─── Notification types ───────────────────────────────────────────────────────
 

--- a/mobile/app/src/sender/SenderFlow.tsx
+++ b/mobile/app/src/sender/SenderFlow.tsx
@@ -13,6 +13,7 @@ import {
 import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
 import { TransferService } from './TransferService';
 import { ShareSheet } from './ShareSheet';
+import { useMobileWallet } from '../hooks/useMobileWallet';
 import { CreateAccountRequest, CreateAccountResponse, SupportedAsset } from '../types/api';
 
 type Step = 'amount' | 'recipient' | 'review' | 'success' | 'error';
@@ -24,6 +25,8 @@ export const SenderFlow: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [response, setResponse] = useState<CreateAccountResponse | null>(null);
   const [showShareSheet, setShowShareSheet] = useState(false);
+  const { session } = useMobileWallet();
+  const connectedPublicKey = session?.publicKey ?? null;
 
   // Form State
   const [amount, setAmount] = useState('');
@@ -48,9 +51,23 @@ export const SenderFlow: React.FC = () => {
     setLoading(true);
     setError(null);
 
+    // `fundingSource` / `recovery_address` are required by the SDK. They must
+    // come from a connected Stellar wallet session; surface a clear error if
+    // no wallet is connected instead of sending a malformed request.
+    if (!connectedPublicKey) {
+      setError('Connect a Stellar wallet to send a payment.');
+      setStep('error');
+      setLoading(false);
+      return;
+    }
+
+    const isNative = selectedAsset.code === 'XLM';
     const request: CreateAccountRequest = {
+      fundingSource: connectedPublicKey,
+      recovery_address: connectedPublicKey,
       amount,
-      asset: `${selectedAsset.code}:${selectedAsset.issuer}`,
+      asset_code: isNative ? 'XLM' : selectedAsset.code,
+      asset_issuer: isNative ? undefined : selectedAsset.issuer,
       expiresIn: 30 * 24 * 60 * 60, // Default 30 days
       metadata: {
         recipientName,
@@ -209,16 +226,18 @@ export const SenderFlow: React.FC = () => {
       
       <View style={styles.linkCard}>
         <Text style={styles.linkText} numberOfLines={1} ellipsizeMode="middle">
-          {response?.claimUrl}
+          {response?.claimUrl ?? 'Claim link unavailable'}
         </Text>
       </View>
 
-      <TouchableOpacity
-        style={styles.shareButton}
-        onPress={() => setShowShareSheet(true)}
-      >
-        <Text style={styles.shareButtonText}>📤 Share Claim Link</Text>
-      </TouchableOpacity>
+      {response?.claimUrl && (
+        <TouchableOpacity
+          style={styles.shareButton}
+          onPress={() => setShowShareSheet(true)}
+        >
+          <Text style={styles.shareButtonText}>📤 Share Claim Link</Text>
+        </TouchableOpacity>
+      )}
 
       <TouchableOpacity
         style={styles.primaryButton}
@@ -232,7 +251,7 @@ export const SenderFlow: React.FC = () => {
         <Text style={styles.buttonText}>Create Another</Text>
       </TouchableOpacity>
 
-      {response && (
+      {response?.claimUrl && (
         <ShareSheet
           visible={showShareSheet}
           claimUrl={response.claimUrl}

--- a/mobile/app/src/sender/TransferService.ts
+++ b/mobile/app/src/sender/TransferService.ts
@@ -1,8 +1,22 @@
 import { apiClient } from '../utils/apiClient';
 import { CreateAccountRequest, CreateAccountResponse, SupportedAsset } from '../types/api';
 
+const DEFAULT_ASSETS: SupportedAsset[] = [
+  {
+    code: 'XLM',
+    issuer: 'native',
+    name: 'Stellar Lumens',
+  },
+  {
+    code: 'USDC',
+    issuer: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+    name: 'USD Coin',
+  },
+];
+
 /**
- * Service to handle transfer operations and ephemeral account management
+ * Service to handle transfer operations and ephemeral account management.
+ * Talks to the Bridgelet SDK's `POST /accounts` endpoint.
  */
 export class TransferService {
   /**
@@ -12,7 +26,7 @@ export class TransferService {
     request: CreateAccountRequest
   ): Promise<CreateAccountResponse> {
     try {
-      const response = await apiClient<CreateAccountResponse>('/api/accounts', {
+      const response = await apiClient<CreateAccountResponse>('/accounts', {
         method: 'POST',
         body: JSON.stringify(request),
       });
@@ -24,30 +38,11 @@ export class TransferService {
   }
 
   /**
-   * Fetch supported assets for transfers
+   * Fetch supported assets for transfers.
+   * The Bridgelet SDK does not currently expose an `/assets` endpoint, so
+   * assets are resolved client-side (with a documented default set).
    */
   static async getSupportedAssets(): Promise<SupportedAsset[]> {
-    try {
-      const response = await apiClient<{ assets: SupportedAsset[] }>('/api/assets', {
-        method: 'GET',
-        skipAuth: true, // Asset list is usually public
-      });
-      return response.assets;
-    } catch (error) {
-      console.error('[TransferService] Failed to fetch supported assets:', error);
-      // Return defaults if API fails
-      return [
-        {
-          code: 'XLM',
-          issuer: 'native',
-          name: 'Stellar Lumens',
-        },
-        {
-          code: 'USDC',
-          issuer: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
-          name: 'USD Coin',
-        },
-      ];
-    }
+    return DEFAULT_ASSETS;
   }
 }

--- a/mobile/app/src/types/api.ts
+++ b/mobile/app/src/types/api.ts
@@ -1,5 +1,7 @@
 /**
- * Metadata for ephemeral account creation
+ * Metadata for ephemeral account creation.
+ * Mirrors the SDK's `CreateAccountDto.metadata` object (PII keys are
+ * stripped server-side; serialised size capped at 4 KB).
  */
 export interface AccountMetadata {
   recipientName: string;
@@ -8,44 +10,67 @@ export interface AccountMetadata {
 }
 
 /**
- * Request body for creating an ephemeral account
+ * Request body for creating an ephemeral account.
+ * Mirrors the SDK's `CreateAccountDto` (POST /accounts). `fundingSource`
+ * and `recovery_address` are required Stellar public keys; asset is sent
+ * as `asset_code` + `asset_issuer` (not a combined "CODE:ISSUER" string).
  */
 export interface CreateAccountRequest {
+  fundingSource: string;
+  recovery_address: string;
   amount: string;
-  asset: string; // Format: "ASSET_CODE:ISSUER"
-  expiresIn: number; // in seconds
-  metadata: AccountMetadata;
+  asset_code?: string;
+  asset_issuer?: string;
+  expiresIn: number; // in seconds (SDK range: 3600–2592000)
+  metadata?: AccountMetadata;
 }
 
 /**
- * Response body for creating an ephemeral account
+ * Response body for creating an ephemeral account.
+ * Mirrors the SDK's `AccountResponseDto`. `claimToken` is intentionally
+ * never returned by the SDK — callers receive a `claimUrl` instead.
  */
 export interface CreateAccountResponse {
   accountId: string;
   publicKey: string;
-  claimUrl: string;
-  claimToken: string;
-  txHash: string;
+  claimUrl: string | null;
+  txHash?: string;
   amount: string;
   asset: string;
-  status: 'pending_payment' | 'unclaimed' | 'claimed' | 'expired';
-  expiresAt: string;
-  createdAt: string;
+  status: AccountStatus;
+  expiresAt: Date;
+  createdAt: Date;
+  claimedAt?: Date | null;
+  destination?: string;
+  metadata?: Record<string, any>;
 }
 
 /**
- * Standard API error structure
+ * Full lifecycle status enum, mirroring the SDK's `AccountStatus`.
+ */
+export type AccountStatus =
+  | 'initializing'
+  | 'pending_payment'
+  | 'pending_claim'
+  | 'claiming'
+  | 'partial_sweep'
+  | 'claimed'
+  | 'expired'
+  | 'failed';
+
+/**
+ * Standard API error structure (SDK error shape).
  */
 export interface ApiError {
-  code: string;
   message: string;
-  details?: Record<string, any>;
-  timestamp: string;
-  requestId?: string;
+  error?: string;
+  statusCode?: number;
 }
 
 /**
- * Supported asset information
+ * Supported asset information.
+ * The SDK does not currently expose an `/assets` endpoint; these values are
+ * resolved client-side.
  */
 export interface SupportedAsset {
   code: string;

--- a/mobile/app/src/utils/apiClient.ts
+++ b/mobile/app/src/utils/apiClient.ts
@@ -60,6 +60,13 @@ export async function apiClient<T>(
     }
   }
 
+  // The Bridgelet SDK authenticates via an `X-API-Key` header (ApiKeyAuthGuard).
+  // Attach it whenever an integrator key is configured.
+  const apiKey = process.env.EXPO_PUBLIC_API_KEY;
+  if (apiKey) {
+    headers.set('X-API-Key', apiKey);
+  }
+
   let lastError: Error | null = null;
 
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {


### PR DESCRIPTION
## Summary

Brings the mobile (Expo) app in line with the actual `bridgelet-sdk` API surface so it can interoperate with the real backend (previously it targeted endpoints/DTOs that don't exist).

## Changes

- **`types/api.ts`**: `CreateAccountRequest` now mirrors SDK `CreateAccountDto` (`fundingSource`, `recovery_address`, `asset_code`/`asset_issuer`); `CreateAccountResponse` mirrors `AccountResponseDto` (nullable `claimUrl`, no bogus `claimToken`); added the 8-value `AccountStatus` enum.
- **`sender/TransferService.ts`**: create via `POST /accounts` (was non-existent `/api/accounts`); removed the fabricated `GET /api/assets` call (SDK has no assets endpoint) -> client-side defaults.
- **`sender/SenderFlow.tsx`**: supply `fundingSource`/`recovery_address` from the connected wallet (`useMobileWallet`); send `asset_code`/`asset_issuer`; guard null `claimUrl`.
- **`components/MobileSendFlow.tsx`**: create claim links via the real `POST /accounts` (was non-existent `POST /claims`), with 401/429 handling and `X-API-Key`.
- **`hooks/useDeepLinkClaim.ts`**: validate via SDK `POST /claims/verify` (was non-existent `GET /claims/{token}/validate`), status mapping mirrors the web frontend.
- **`claims/service.ts`**: `lookupClaimByToken` now calls the SDK server-side instead of local JWT decode (SDK tokens sign `publicKey/type/jti`, not account fields).
- **`utils/apiClient.ts`**: attach `X-API-Key` header (SDK uses global `ApiKeyAuthGuard`).
- **`.env.example`**: add `EXPO_PUBLIC_FUNDING_ACCOUNT` and `EXPO_PUBLIC_API_KEY`.

## Verification
- `tsc --noEmit` passes
- `jest` passes (8 tests)

## Notes
- `/notifications/*` and `/api/translate/detect` still lack SDK counterparts; both degrade gracefully.
- Flagged separately: SDK's global `ApiKeyAuthGuard` currently guards `/claims/*`, contradicting the web frontend's direct-claim model.
